### PR TITLE
Add db-migration-agent-skill: database migration to Aurora/RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The same `SKILL.md` runs identically across three AI tools — the only differen
 | **[graph-personalization-skill](./graph-personalization-skill/)** | Customer similarity graph (Neptune) + Bedrock explainable recommendations + Kinesis real-time | *"Graph-based personalized recommendations"* | `shared/` + thin SKILL.md |
 | **[data-platform-pipeline-skill](./data-platform-pipeline-skill/)** | S3 (3-bucket) + Glue + Athena — *source → queryable data* | *"Build a data pipeline"* | Monolithic SKILL.md (~50 KB) |
 | **[data-platform-consumption-skill](./data-platform-consumption-skill/)** | QuickSight + Amazon Quick chat agents — *queryable data → BI* | *"Set up a QuickSight dashboard"* | Monolithic SKILL.md (~60 KB) |
+| **[db-migration-agent-skill](./db-migration-agent-skill/)** | EC2/on-prem databases (MySQL · MariaDB · PostgreSQL · Oracle · SQL Server · Db2) → Aurora / RDS — assessment, method selection, CDK provisioning, client repointing, soak, rehearsed cutover, rollback | *"Migrate my database to Aurora"* | `shared/` + thin SKILL.md |
 | **[llm-gateway-governance-skill](./llm-gateway-governance-skill/)** | LiteLLM gateway + Bedrock Guardrails + SSO/Cognito virtual keys + ECS Fargate + ALB edge (certMode: acm/http, SG CIDR-restricted) | *"Build an LLM gateway to govern Bedrock"* | `shared/` + thin SKILL.md |
 
 > **Two authoring styles coexist** (both produce md5-identical `SKILL.md` across all three tools):

--- a/db-migration-agent-skill/README.md
+++ b/db-migration-agent-skill/README.md
@@ -1,0 +1,263 @@
+# db-migration-agent-skill
+
+An Agent Skill that turns your coding agent — **Claude Code, Kiro, or Codex** — into a
+database migration engineer. You describe the database you want moved to AWS; the agent
+plans and executes the migration end to end, and **you approve every decision that
+matters** before it happens.
+
+It moves self-managed databases (on EC2, on-premises, or another cloud) to **Amazon
+Aurora or Amazon RDS**. Supported sources: MySQL, MariaDB, PostgreSQL, Oracle, SQL
+Server, Db2 — plus playbooks for heterogeneous moves (e.g. SQL Server → Aurora
+PostgreSQL) and Korean-market engines and security appliances.
+
+## What using it feels like
+
+You start by telling the agent something like *"we run MySQL on an EC2 instance and want
+to move to Aurora — we can tolerate about a minute of downtime and can't lose data."*
+From there:
+
+1. **Two framing questions.** Before anything else, the agent asks what kind of
+   engagement this is — a **report only** (it inspects and recommends, guaranteed
+   read-only), a **practice run** against a clone of your database, or the **real
+   migration** — and **how critical the database is** ("if it's wrong for an hour, what
+   happens?"). Those two answers decide how much ceremony everything else gets: a dev
+   database gets a fast path; an order system gets a required rehearsal and a soak
+   period; a payments ledger gets timed dress rehearsals and daily reconciliation.
+
+2. **A short interview.** ~17 questions, one at a time, each with a recommended default —
+   say **"go with recommendations"** and it skips to the end. It asks the things teams
+   forget until it's too late: who else reads this database? any backup/monitoring/
+   security agents on the host? what happens to you if a rollback loses ten minutes of
+   writes?
+
+3. **It inspects your environment — read-only.** Connects via SSM (no SSH keys, no
+   passwords typed anywhere), scans for the things that break managed databases
+   (unsupported storage engines, encryption plugins, privileged code), measures the
+   database, finds **every application that connects to it** (including the ones hiding
+   in cron jobs and hardcoded IPs), and captures a performance baseline. Anything it
+   finds becomes a written finding — nothing is "fixed" without your sign-off.
+
+4. **You approve the plan.** It presents the migration method it recommends (and the
+   ones it rejected, with reasons), the downtime forecast, the rollback strategy, the
+   target architecture, and an **itemized monthly + one-time cost**. Nothing is built
+   until you say yes.
+
+5. **It builds and migrates.** The target (Aurora/RDS) is created from a CDK project you
+   keep — encrypted, private, monitored, with alarms live before any data moves. Data
+   moves by the fastest safe method for your case (often native tools, not DMS), while
+   your application keeps running on the old database.
+
+6. **It proves the copy is right.** Row counts on every table, checksums on critical
+   ones, your stored procedures executed on the target, and — for business-critical
+   databases — a **soak period**: the new database runs in parallel, kept current in
+   real time, with a daily green/red report. The cutover stays locked until it has been
+   green for N consecutive days (you pick N) and a named person signs off.
+
+7. **Cutover night runs from a rehearsed script.** You approve the window. The agent
+   freezes the old database, drains the last changes, flips your applications to the new
+   endpoint, and verifies **in both directions** — your app reports healthy *and* the new
+   database shows every expected client connected. Measured pause is reported to you
+   straight, whatever it is. Reverse replication is armed **before** the flip, so for
+   the whole rollback window (default 7 days) the old server stays a live, current
+   standby — one command fails everything back with zero data loss.
+
+8. **Nothing is deleted without written sign-off.** The old server is only decommissioned
+   after the rollback window closes and you've signed the exact teardown list.
+
+## What you'll be asked — and never asked
+
+**You'll be asked** at four gates: to confirm the interview answers, to approve the
+method + cost, to accept the validation evidence, and to green-light the cutover window.
+Every approval is recorded in a generated `authorizations.md` with a name and date — an
+audit record you can hand to your security team. Skipping a safety step (like the
+rehearsal) is possible, but only as a **written waiver** with the risk spelled out.
+
+**You'll never be asked** to paste a password into chat (credentials live in AWS Secrets
+Manager and are fetched on-host), to approve vague actions ("can I fix some things?" —
+every production write is itemized), or to trust "it worked" without evidence.
+
+## What you get
+
+| Artifact | What it is |
+|---|---|
+| `migration-plan.md` | The running record — every decision and why, every result, every gate |
+| `authorizations.md` | Who approved what, when — including any waivers |
+| `{prefix}-migration/` | A deployable CDK (TypeScript) project for the new database — yours to keep |
+| `cutover-runbook.md` / `rollback-runbook.md` | The scripts as executed, with measured timings |
+| Soak reports | Daily green/red evidence during the parallel-run period (Tier 2+) |
+
+## What this skill is NOT — read before setting expectations
+
+The skill is deliberately scoped. These are the things a customer might reasonably
+assume it does, but it doesn't — each is a conscious boundary, not an oversight:
+
+**1. It does not edit your application code.** Connection *config* changes (endpoint in
+a secret, systemd unit, ConfigMap) are in scope — delivered as an exact change spec your
+team commits to your own repo. Application *logic* is not: for heterogeneous moves it
+emits `app-remediation-findings.md` (file:line, offending construct, replacement) as a
+handoff for your dev team — or a second agent session opened in your repo with your
+tests. It never asks for access to your source control.
+
+**2. Oracle RAC (and other multi-writer/clustered sources) are NOT supported as
+like-for-like migrations.** There is no RAC on RDS or Aurora — a RAC estate cannot be
+"migrated" by this skill; it requires an architecture redesign (single writer + readers)
+that is its own project, owned by your architects. The skill will detect a RAC source
+during assessment, say exactly this, and stop short of promising a migration. What IS
+supported for Oracle: single-instance Oracle → RDS for Oracle (lift-and-shift), and
+single-instance Oracle → Aurora PostgreSQL as a conversion project where the skill runs
+the data workstream and hands your team the code-conversion findings. For any
+heterogeneous move, remember the app/code conversion — not the data — is usually the
+schedule.
+
+**3. Tight downtime numbers are earned, not promised.** Generous windows (hours) are
+routinely achievable; tight budgets (≤ 60–120 s) depend on details that only a rehearsal
+surfaces — engine-version syntax quirks, connection-pool behavior, per-step dispatch
+latency. The skill's rule: quote a cutover window only from a **measured rehearsal**,
+and treat rehearsal × 2 as the honest budget. If someone needs a guaranteed sub-minute
+cutover with no rehearsal, this skill will refuse to promise it — that's a feature.
+
+**4. It is not unattended.** A named human approves the mode, tier, method, cost, and
+cutover, and is reachable during the window. The skill is designed to *stop and ask*
+when an abort criterion trips mid-cutover rather than decide on its own — which only
+works if someone is there to answer.
+
+**5. Large-scale migrations are planned honestly, not waved through.** The decision
+matrix has explicit > 1 TB paths — XtraBackup + S3 physical seed with CDC catch-up
+(MySQL-family), Oracle transportable tablespaces (EE-only, with real preconditions),
+SQL Server full+diff+log chains (≤ 64 TiB per native restore), and an offline-seed
+branch (Snow Family / DataSync) with the record-the-replication-position discipline that
+keeps an offline seed lossless. But hard bounds remain that no tool changes: moving N
+terabytes takes `N / usable-bandwidth` — the skill computes this in Phase 2 and routes
+to Snow (adding days–weeks of device shipping) rather than pretending; Aurora storage
+caps at 128 TiB; a single S3 dump object at 5 TiB. For any multi-TB engagement treat the
+rehearsal as mandatory regardless of tier, and note that multi-TB + near-zero-downtime +
+heterogeneous *combined* is a phased program, not one engagement. The skill will give
+you an honest plan and run the data workstream — expect it to tell you things (shipping
+time, multi-week CDC catch-up, phased cutover) that no tool can make disappear.
+
+**6. Some sources have no tooling fast-path.** Tibero, CUBRID, Altibase (no AWS
+DMS/SCT support): the skill plans a PoC + JDBC extraction path and says so plainly
+rather than implying DMS will "just work".
+
+**7. Not covered at all**: sharded/multi-master topologies as such (Galera,
+Group Replication — flagged as redesigns), NoSQL sources, data-warehouse migrations
+(Redshift territory), ongoing post-migration DBA operations (that's the `aws-database`
+skills' ground), and BYO-license procurement decisions (it surfaces the LI/BYOL choice;
+your licensing team owns it).
+
+## Layout
+
+Follows the [aws-samples/sample-aws-solutions-skills](https://github.com/aws-samples/sample-aws-solutions-skills)
+conventions — one canonical `SKILL.md`, byte-identical per tool, all knowledge in `shared/`:
+
+```
+db-migration-agent-skill/
+├── README.md
+├── claude-code/skills/db-migration-agent/SKILL.md   ★ canonical source — edit THIS one
+├── kiro/skills/db-migration-agent/SKILL.md          ★ md5-identical copy
+├── codex/skills/db-migration-agent/SKILL.md         ★ md5-identical copy
+├── shared/
+│   ├── reference/
+│   │   ├── preflight-iam-cost.md           Phase 0 — preconditions, IAM roles, cost, monitoring baseline
+│   │   ├── source-assessment.md            Phase 2 — blockers, access paths, credential rules, sizing, Snow branch
+│   │   ├── rds-aurora-limitations.md       Full blocker/adjustment catalog with queries
+│   │   ├── method-selection.md             Phase 3 — 18-row decision matrix, binlog gate, edge cases
+│   │   ├── heterogeneous-migration.md      SCT / DMS SC / Babelfish; Tibero/CUBRID/Altibase
+│   │   ├── target-provisioning.md          Phase 4 — Aurora vs RDS, immutable settings, RDS Proxy, TLS gate
+│   │   ├── execution-runbooks.md           Phase 6 — per-method procedures, schema objects, rehearsal
+│   │   ├── dms-best-practices.md           DMS sizing, task settings, LOB handling
+│   │   ├── aws-official-migration-methods.md  All 33 AWS-documented methods
+│   │   ├── validation-patterns.md          Phase 7 — counts/checksums/app-level/version-gap
+│   │   ├── version-upgrades.md             Major-version-gap behavioral changes
+│   │   ├── cutover-procedures.md           Phases 7.5–8 — client discovery, freeze, reverse replication, rollback
+│   │   ├── post-migration.md               Phase 9
+│   │   ├── troubleshooting.md              Symptom → fix
+│   │   ├── mcp-and-tooling.md              AWS MCP Server / Agent Toolkit / companion MCP servers
+│   │   ├── engagement-safety.md            Modes, criticality tiers, waivers, IAM guardrails
+│   │   ├── third-party-db-security.md      Third-party DB security tools (global + Korean deep-dive)
+│   │   └── regulatory-compliance.md        Korean regulatory mandates (PIPA, network separation, ISMS-P)
+│   ├── patterns/
+│   │   └── cdk-stacks.md                   The CDK project the skill generates
+│   └── templates/
+│       ├── migration-plan.md               Working artifact (source of truth per engagement)
+│       ├── authorizations.md               Named-approver audit record
+│       ├── soak-report.md                  Daily green/red gate during the parallel run
+│       ├── cutover-runbook.md              Instantiated with real values at Phase 8
+│       └── rollback-runbook.md
+├── evals/                                  Black-box eval scenarios (expected-behavior checklists)
+│   ├── ec2-mysql-to-aurora-scenario.md
+│   └── sqlserver-to-aurora-pg-scenario.md
+```
+
+## Install
+
+`shared/` must be installed alongside `SKILL.md` so relative references resolve.
+
+```bash
+# Claude Code
+mkdir -p ~/.claude/skills/db-migration-agent
+cp claude-code/skills/db-migration-agent/SKILL.md ~/.claude/skills/db-migration-agent/
+cp -r shared evals ~/.claude/skills/db-migration-agent/
+
+# Kiro
+mkdir -p ~/.kiro/skills/db-migration-agent
+cp kiro/skills/db-migration-agent/SKILL.md ~/.kiro/skills/db-migration-agent/
+cp -r shared evals ~/.kiro/skills/db-migration-agent/
+
+# Codex
+mkdir -p ~/.agents/skills/db-migration-agent
+cp codex/skills/db-migration-agent/SKILL.md ~/.agents/skills/db-migration-agent/
+cp -r shared evals ~/.agents/skills/db-migration-agent/
+```
+
+## MCP requirements (optional — CLI fallback always works)
+
+Recommended: the **AWS MCP Server** via the Agent Toolkit for AWS
+(`/plugin install aws-core@claude-plugins-official` in Claude Code), which also provides
+`retrieve_skill` for chaining the official `dms-schema-conversion` skill on heterogeneous
+migrations. Optional companions: `awslabs.mysql-mcp-server` / `postgres` / `oracle` /
+`mssql` (query source/target without local clients), `awslabs.cloudwatch-mcp-server`
+(DMS metrics), `awslabs.aws-pricing-mcp-server` (GATE 2 cost estimate). Details:
+`shared/reference/mcp-and-tooling.md`.
+
+## Trigger phrases
+
+**English**: "migrate database", "move to Aurora", "migrate to RDS", "EC2 MySQL to
+Aurora", "SQL Server to Aurora PostgreSQL", "database cutover", "DMS migration",
+"database modernization".
+**Other languages**: the skill answers in the customer's language (Korean fully
+supported) — trigger it with the equivalent phrases in that language.
+
+## For operators: modes & tiers in one line each
+
+Details in `shared/reference/engagement-safety.md`. Modes: `assessment-only` (physically
+read-only), `staging-rehearsal` (clone only), `production-migration` (requires a prior
+assessment). Tiers: 1 Standard (fast path), 2 Business-critical (default: rehearsal +
+soak required), 3 Mission-critical (timed rehearsals to convergence, reconciliation,
+war-room cutover). An IAM guardrail policy denies source-destructive actions until the
+decommission sign-off.
+
+## The opinionated choices
+
+- **DMS is not the default.** Native tools (mysqldump, XtraBackup+S3, pg_dump, Data Pump,
+  native .bak restore) are faster for homogeneous moves and carry schema objects; the
+  matrix in `shared/reference/method-selection.md` is walked top-down, first match wins.
+- **Four user gates** (inputs → method+cost → validation → cutover). Everything else the
+  agent executes itself.
+- **No cutover without a complete client inventory and a signed rollback path** —
+  reverse replication where possible, write-log replay or explicit RPO acknowledgment
+  where not.
+
+## Contributing / editing
+
+Edit **only** `claude-code/skills/db-migration-agent/SKILL.md` and `shared/`, then sync
+the three copies from the repo root:
+
+```bash
+scripts/sync-skills.sh db-migration-agent-skill
+scripts/sync-skills.sh verify
+```
+
+## License
+
+MIT.

--- a/db-migration-agent-skill/claude-code/skills/db-migration-agent/SKILL.md
+++ b/db-migration-agent-skill/claude-code/skills/db-migration-agent/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: db-migration-agent
+description: |
+  Plan and execute production database migrations to AWS managed services — MySQL, MariaDB,
+  PostgreSQL, Oracle, SQL Server, Db2 (on EC2, on-premises, or another cloud) to Amazon
+  Aurora or Amazon RDS, homogeneous or heterogeneous. Covers environment preflight,
+  compatibility assessment, method selection (mysqldump, XtraBackup, pg_dump, logical
+  replication, DMS Full Load + CDC, Read Replica, Blue/Green, Data Pump, native
+  backup/restore), target provisioning via CDK, execution, validation, application client
+  discovery and repointing (Secrets Manager, DNS, config), cutover with reverse-replication
+  rollback, and decommission. Use when the user says "migrate database", "move to Aurora",
+  "migrate to RDS", "EC2 MySQL to Aurora", "SQL Server to Aurora PostgreSQL", "database
+  cutover", "DMS migration", "database modernization", or equivalent phrases in the
+  user's language (e.g. Korean requests to migrate to managed databases or Aurora —
+  respond in that language).
+license: MIT
+metadata:
+  version: "2.0"
+  author: aws-solution-skills
+---
+
+# DB Migration Agent Skill
+
+## Purpose
+
+Run a real production database migration end to end: examine the current environment,
+gather the decision inputs, move the data reliably by the right method, repoint every
+application client, cut over with a rehearsed runbook and a working rollback, and leave
+the customer a CDK project plus a complete written record. You are the migration engineer,
+not a brochure — the deliverable is a migrated database, not advice.
+
+> **Language**: respond in the user's language (Korean → Korean). Code, CLI, CDK, SQL,
+> and resource names stay in English.
+
+## 🔴 Hard constraints (never violate)
+
+1. **`migration-plan.md` is the source of truth.** Create it from
+   `shared/templates/migration-plan.md` at Phase 0; record every result, decision + why,
+   and sign-off as it lands. A step without its result written down is not done.
+2. **Never write to the production source.** Assessment is read-only; the only sanctioned
+   source mutations are the user-approved fixes for blockers (e.g. `ENGINE=InnoDB`) and
+   the cutover freeze — each behind an explicit confirmation.
+3. **The user approves the method, the cost, and the cutover** (GATES 2 and 4). Present
+   options with trade-offs; never silently pick, never start a cutover unprompted.
+4. **No credentials in argv or in files you generate.** `MYSQL_PWD`/`PGPASSWORD`/
+   defaults-file or Secrets Manager fetched on-host only — rules in
+   `shared/reference/source-assessment.md`.
+5. **DMS ≠ default.** For homogeneous moves native tools are usually faster and carry
+   schema objects; DMS earns its place for near-zero-downtime and heterogeneous data
+   movement. Follow the decision matrix, top row first match.
+6. **No cutover before the client inventory is 100% complete** (Phase 7.5) — a missed
+   client means split-brain writes or an outage. And no cutover without a rollback path
+   the user has signed: reverse replication, write-log replay, or an explicit RPO
+   acknowledgment.
+7. **Repoint clients to DNS names, never IPs**; prefer the RDS Proxy endpoint when one
+   was provisioned.
+8. **Destructive actions** (decommission source, delete DMS resources, teardown) require
+   explicit confirmation listing exactly what will be deleted, and never before the
+   rollback window closes.
+9. **The engagement mode and criticality tier govern the ceremony** (see
+   `shared/reference/engagement-safety.md`): assessment-only sessions are physically
+   read-only; production cutover requires the tier's requirements satisfied (rehearsal,
+   soak green-days) **or a recorded waiver** — and approvals of record live in
+   `authorizations.md` (named person + date), not in chat scrollback.
+
+## Execution model
+
+You have terminal access — run the commands yourself; don't paste walls of commands for
+the user to run (exception: commands that must run on hosts you can't reach — hand those
+over as a single copy-paste block and ask for the output).
+
+| Agent does silently | Agent asks the user |
+|---|---|
+| Preflight checks, read-only assessment queries, sizing math, doc verification via MCP | Anything in GATES 1–4; blocker-fix approval; production writes |
+| `cdk synth`, deploy of the target stacks after GATE 2 | Cutover window scheduling; go/no-go at each cutover step group |
+| Validation queries, evidence collection, plan updates | Accepting a non-lossless rollback (RPO sign-off) |
+| Retrying transient AWS errors (≤3, backoff) | Quota increases, cross-account access, anything needing other teams |
+
+## Knowledge sources (load on demand — do not preload)
+
+| File | Read when |
+|------|-----------|
+| `shared/reference/engagement-safety.md` | Phase 0 — engagement modes, criticality tiers + ceremony matrix, waiver protocol, IAM guardrails |
+| `shared/reference/preflight-iam-cost.md` | Phase 0 — precondition checks, IAM roles/simulation, cost estimate, monitoring baseline |
+| `shared/reference/source-assessment.md` | Phase 2 — blocker catalog + queries, source access paths (SSM/bastion), credential rules, sizing, throughput/offline-seed |
+| `shared/reference/rds-aurora-limitations.md` | Phase 2 — full per-limitation detail behind the blocker tables |
+| `shared/reference/method-selection.md` | Phase 3 — the 18-row decision matrix, binlog gate, multi-DB/cross-region/cross-account edges |
+| `shared/reference/heterogeneous-migration.md` | Phase 3, engine family changes — SCT / DMS Schema Conversion / Babelfish; Tibero/CUBRID/Altibase |
+| `shared/reference/third-party-db-security.md` + `regulatory-compliance.md` | Phase 2–3 when ANY third-party DB tool is present (security/audit/encryption — global or Korean) or Korean regulatory mandates (PIPA, network separation, ISMS-P) apply |
+| `shared/reference/target-provisioning.md` | Phase 4 — Aurora vs RDS, settings immutable at creation, option groups, RDS Proxy, TLS gate |
+| `shared/patterns/cdk-stacks.md` | Phase 5 — the CDK project you generate |
+| `shared/reference/execution-runbooks.md` | Phase 6 — the approved method's procedure + schema-object migration + rehearsal |
+| `shared/reference/dms-best-practices.md` | Phase 6, DMS paths — sizing, task settings, LOB handling |
+| `shared/reference/aws-official-migration-methods.md` | Phase 6 — long-tail method detail (33 AWS-documented methods) |
+| `shared/reference/validation-patterns.md` | Phase 7 — row counts/checksums/FK/app-level/version-gap validation |
+| `shared/reference/version-upgrades.md` | Phase 7 when source→target crosses a major version |
+| `shared/reference/customer-test-integration.md` | Phase 6.5/7.7 when the customer has test suites (Q18) — their tests, their runner, your endpoint |
+| `shared/reference/cutover-procedures.md` | Phases 7.5–8 — client discovery, freeze, write-pause minimization, reverse replication, rollback |
+| `shared/templates/{migration-plan,authorizations,cutover-runbook,rollback-runbook,soak-report}.md` | Phase 0 / 7.7 / 8 — instantiate with real values |
+| `shared/reference/post-migration.md` | Phase 9 |
+| `shared/reference/troubleshooting.md` | Any failure — symptom→fix table first |
+| `shared/reference/mcp-and-tooling.md` | Session start if MCP available; anytime tooling questions arise |
+
+## Workflow
+
+### Phase 0: Preflight
+
+1. Ask the **engagement-mode question first** (`shared/reference/engagement-safety.md`):
+   **assessment-only** (read-only, ends with a report), **staging-rehearsal** (migrate a
+   clone, never production), or **production-migration** (locked unless an assessment
+   report exists). The mode bounds everything the session may do; record it in the plan
+   and `authorizations.md` §1, and generate the mode's IAM guardrail policy.
+2. Create `migration-plan.md` and `authorizations.md` from the templates in the working
+   directory.
+3. Ask the **current-state question**: fresh engagement / plan exists, resume at phase N
+   / migration failed midway, triage? Resume from the plan file if it exists.
+4. Run the precondition checks (`shared/reference/preflight-iam-cost.md` §1) — identity,
+   account, region, source reachability, engine-version availability, quotas, IAM
+   simulation. Report ✅/❌ table. **STOP on ❌ and wait.**
+5. Note which MCP servers are connected (`shared/reference/mcp-and-tooling.md`).
+   Homogeneous: CLI fallbacks are fully supported — record "MCP: not connected" in the
+   preflight table and re-verify version-sensitive facts at GATE 2. **Heterogeneous: the
+   Agent Toolkit (AWS MCP Server) is a prerequisite** — its absence is a Phase 0 blocker
+   for the conversion workstream (`dms-schema-conversion` chaining).
+
+### Phase 1: Discovery (batched per gate, each question with a recommended default)
+
+Ask discovery questions **as one batched message per gate** — a numbered list with a
+recommended default per item and a "go with recommendations" fast path — not one question
+per turn (customers consistently push back on drip-feed questioning; asynchronous
+stakeholders doubly so). Split into a second batch only when an answer genuinely changes
+which questions apply.
+
+Collect the 17 inputs in the plan template §Phase 1 — source engine/location, target,
+size, **downtime tolerance**, **RPO on rollback**, usable bandwidth, schema-object needs,
+app modifiability, **how each app finds the DB today**, downstream CDC consumers,
+compliance mandates, **Korean security appliances and their mode**, multi-DB,
+cross-region/account, KMS key type, **criticality tier** (#16 — use the "if this DB is
+wrong for an hour, what happens?" guidance in engagement-safety.md; customers habitually
+under-tier), **third-party tools on or in front of the DB** (#17 — security, backup,
+monitoring, HA, proxy agents; customers usually forget these until asked), and the
+**customer's own test suite** (#18 — regression/UAT/load tests their QA already runs;
+these become acceptance gates executed against the target during rehearsal and soak —
+integration mechanics in `shared/reference/customer-test-integration.md`: their tests
+run in *their* CI/QA systems pointed at the target endpoint, never pasted into chat). "Go with recommendations" accepts all remaining defaults. Skip what's
+already known.
+
+⛔ **GATE 1** — summarize the inputs in the plan; user confirms before any assessment.
+**Mode + tier are locked here** and signed in `authorizations.md` §3; the tier's ceremony
+matrix (engagement-safety.md) is binding from this point.
+
+### Phase 2: Assess the source (read-only)
+
+Per `shared/reference/source-assessment.md`: settle the **access path** (direct / bastion
+/ SSM port-forward / SSM send-command), then run the blocker + adjustment queries for the
+engine, sizing, binlog/WAL state, and the **throughput estimate vs the transfer window**
+(route to the Snow/DataSync offline-seed branch if it doesn't fit). Capture the
+**performance baseline** (top-20 statements + plans). Korean-enterprise check runs here.
+Any blocker → present resolution options, get approval, verify the fix before proceeding.
+
+### Phase 3: Select the method
+
+Per `shared/reference/method-selection.md`: walk the decision matrix top-down, take the
+first matching row; apply the **binlog state gate** ("zero-downtime" with `log_bin=OFF` is
+a contradiction — surface it). Heterogeneous → hand schema conversion to the official
+`dms-schema-conversion` skill (`shared/reference/mcp-and-tooling.md` §Chaining), then
+return here for data movement. Prepare the **cost estimate**
+(`shared/reference/preflight-iam-cost.md` §3).
+
+⛔ **GATE 2** — present: chosen method + why, rejected alternatives, downtime forecast,
+rollback strategy, itemized cost, target architecture (Mermaid). User approves.
+
+### Phase 4–5: Provision the target
+
+Per `shared/reference/target-provisioning.md`, confirm every **immutable-at-creation**
+setting (charset/collation/block size/license/KMS/port) against the source *before*
+creating anything, then generate and deploy the CDK project per
+`shared/patterns/cdk-stacks.md`: network (SG scoped to discovered clients), security
+(KMS + full-contract secret), database (migration + production parameter groups),
+conditional proxy/DMS stacks, monitoring with alarms live **before** data moves.
+`cdk synth` must pass; verify volatile facts via MCP.
+
+### Phase 6: Execute the migration
+
+Follow the approved method's runbook in `shared/reference/execution-runbooks.md` only.
+Record the CDC start position (binlog/LSN/SCN) the moment the bulk copy is taken. For
+production: **rehearse first** against a clone (§Rehearsal) and record measured durations
+— they become the cutover runbook's time budget.
+
+### Phase 7: Validate
+
+Per `shared/reference/validation-patterns.md`: row counts (all tables), checksums
+(critical tables), schema-object counts, FK orphans, app-level checks (collation order,
+timezone shift, auto-increment high-water marks, aggregate fidelity), read-only smoke
+test. Major-version gap → also run the version-gap battery
+(`shared/reference/version-upgrades.md`). Paste evidence into the plan.
+
+⛔ **GATE 3** — all validation green, recorded. No cutover date before this.
+
+### Phase 7.5: Discover every DB client (mandatory)
+
+Per `shared/reference/cutover-procedures.md` §client discovery: SG-ingress trace → each
+client's connection config in **override order** (process args → env → systemd → config →
+secret → hardcoded IPs; ECS task defs / K8s ConfigMaps / Lambda env for containerized
+clients) → cross-check against the live processlist → plan for **downstream
+replication/CDC consumers** (Debezium, replicas, ELT tools — they can't be repointed,
+they restart from the target's coordinates). Pre-tune connection pools; disable ORM
+auto-DDL. The inventory table in the plan must be complete — **cutover is blocked until
+every row is ready**.
+
+### Phase 7.7: Parallel-run soak (Tier 2/3 — cutover stays locked until it passes)
+
+The target runs live and CDC-current while production stays on the source, for the
+customer-chosen soak length (Tier 2 default: 7 consecutive green days; Tier 3 adds
+performance validation and reconciliation — `shared/reference/engagement-safety.md`).
+Each day: generate a report from `shared/templates/soak-report.md` (lag, spot
+counts/checksums, alarms, drift) and send it to the customer; any RED day resets the
+consecutive-green counter. Client discovery (7.5) runs alongside the soak. Invite the
+customer to point read-only test traffic or load tests at the target during this window.
+Cutover scheduling unlocks only at **N consecutive greens + the signed soak-exit row** in
+`authorizations.md`. Shortening or skipping the soak is a waiver (engagement-safety.md
+§Waiver protocol).
+
+### Phase 8: Cut over
+
+Instantiate `shared/templates/cutover-runbook.md` and `rollback-runbook.md` with real
+values (zero placeholders). Reverse replication created and tested **before** the window
+— or the alternative rollback strategy signed (RPO acknowledgment in the plan).
+
+⛔ **GATE 4** — walk the user through the runbook; they approve the window and the
+rollback strategy. Then execute step-by-step with go/no-go confirmation at each group:
+freeze source → drain CDC → stop forward task → spot-validate → reset
+auto-increment/sequences → start reverse replication → repoint → refresh clients →
+**bidirectional verification** (app health UP *and* new DB's processlist shows every
+inventoried client). Watch the abort criteria at T+15m/T+1h/T+24h.
+
+### Phase 9: Post-migration
+
+Per `shared/reference/post-migration.md`: refresh statistics, swap to the production
+parameter group, scale down, compare against the Phase 2 baseline, keep the source +
+reverse replication through the 7-day window, then decommission (with constraint 8's
+confirmation). Hand over the CDK project + plan as the customer's operational record.
+
+## When to call MCP
+
+Convention: MCP-first for volatile facts and audited execution, AWS CLI fallback always
+works. Details + install: `shared/reference/mcp-and-tooling.md`.
+
+| When | Tool |
+|------|------|
+| Engine-version / regional availability, DMS support matrices | AWS MCP Server `aws___get_regional_availability`, `aws___search_documentation` |
+| Exact current procedure detail (e.g. `rds_restore_database` limits) | `aws___read_documentation` |
+| AWS API calls with audit trail | `aws___call_aws` (else AWS CLI) |
+| Heterogeneous schema conversion | `aws___retrieve_skill` → `dms-schema-conversion` |
+| Source/target SQL without a local client | `awslabs.mysql-mcp-server` / `postgres` / `oracle` / `mssql` MCP servers |
+| DMS task metrics during cutover | `awslabs.cloudwatch-mcp-server` |
+| Cost estimate at GATE 2 | `awslabs.aws-pricing-mcp-server` |
+
+⚠️ Never install `awslabs.aws-dms-mcp-server` from PyPI — squatted, not AWS.
+
+## Output contract
+
+By the end of an engagement the working directory contains:
+
+1. **`migration-plan.md`** — complete, every gate signed, evidence embedded.
+2. **`authorizations.md`** — mode/tier sign-offs, action-class authorizations, waivers —
+   the customer's audit record.
+3. **`{prefix}-migration/`** — the deployed CDK project (`shared/patterns/cdk-stacks.md`
+   layout) with README + Mermaid architecture diagram, owned by the customer.
+4. **`cutover-runbook.md` + `rollback-runbook.md`** — as executed, with measured timings
+   — and, for Tier 2/3, the daily **soak reports**.
+(Assessment-only mode delivers items 1–2 plus the assessment report; no infrastructure.)
+
+## Common mistakes (learned the hard way)
+
+- Assuming DMS migrates stored procedures/triggers/views/sequences/grants — it doesn't;
+  schema objects travel separately (execution-runbooks §schema objects).
+- Freezing the source *after* repointing — split-brain. Freeze first, always.
+- Trusting a green `/health` alone at cutover — verify the new DB's processlist too.
+- Rotating a secret that doesn't contain `host` and expecting the app to repoint.
+- Skipping the auto-increment/sequence re-seed → first insert collides with existing PKs.
+- Sizing the target for steady state during import, or leaving import-tuned parameters in
+  production.
+- Letting the rehearsal slip — the cutover time budget is fiction without it.

--- a/db-migration-agent-skill/codex/skills/db-migration-agent/SKILL.md
+++ b/db-migration-agent-skill/codex/skills/db-migration-agent/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: db-migration-agent
+description: |
+  Plan and execute production database migrations to AWS managed services — MySQL, MariaDB,
+  PostgreSQL, Oracle, SQL Server, Db2 (on EC2, on-premises, or another cloud) to Amazon
+  Aurora or Amazon RDS, homogeneous or heterogeneous. Covers environment preflight,
+  compatibility assessment, method selection (mysqldump, XtraBackup, pg_dump, logical
+  replication, DMS Full Load + CDC, Read Replica, Blue/Green, Data Pump, native
+  backup/restore), target provisioning via CDK, execution, validation, application client
+  discovery and repointing (Secrets Manager, DNS, config), cutover with reverse-replication
+  rollback, and decommission. Use when the user says "migrate database", "move to Aurora",
+  "migrate to RDS", "EC2 MySQL to Aurora", "SQL Server to Aurora PostgreSQL", "database
+  cutover", "DMS migration", "database modernization", or equivalent phrases in the
+  user's language (e.g. Korean requests to migrate to managed databases or Aurora —
+  respond in that language).
+license: MIT
+metadata:
+  version: "2.0"
+  author: aws-solution-skills
+---
+
+# DB Migration Agent Skill
+
+## Purpose
+
+Run a real production database migration end to end: examine the current environment,
+gather the decision inputs, move the data reliably by the right method, repoint every
+application client, cut over with a rehearsed runbook and a working rollback, and leave
+the customer a CDK project plus a complete written record. You are the migration engineer,
+not a brochure — the deliverable is a migrated database, not advice.
+
+> **Language**: respond in the user's language (Korean → Korean). Code, CLI, CDK, SQL,
+> and resource names stay in English.
+
+## 🔴 Hard constraints (never violate)
+
+1. **`migration-plan.md` is the source of truth.** Create it from
+   `shared/templates/migration-plan.md` at Phase 0; record every result, decision + why,
+   and sign-off as it lands. A step without its result written down is not done.
+2. **Never write to the production source.** Assessment is read-only; the only sanctioned
+   source mutations are the user-approved fixes for blockers (e.g. `ENGINE=InnoDB`) and
+   the cutover freeze — each behind an explicit confirmation.
+3. **The user approves the method, the cost, and the cutover** (GATES 2 and 4). Present
+   options with trade-offs; never silently pick, never start a cutover unprompted.
+4. **No credentials in argv or in files you generate.** `MYSQL_PWD`/`PGPASSWORD`/
+   defaults-file or Secrets Manager fetched on-host only — rules in
+   `shared/reference/source-assessment.md`.
+5. **DMS ≠ default.** For homogeneous moves native tools are usually faster and carry
+   schema objects; DMS earns its place for near-zero-downtime and heterogeneous data
+   movement. Follow the decision matrix, top row first match.
+6. **No cutover before the client inventory is 100% complete** (Phase 7.5) — a missed
+   client means split-brain writes or an outage. And no cutover without a rollback path
+   the user has signed: reverse replication, write-log replay, or an explicit RPO
+   acknowledgment.
+7. **Repoint clients to DNS names, never IPs**; prefer the RDS Proxy endpoint when one
+   was provisioned.
+8. **Destructive actions** (decommission source, delete DMS resources, teardown) require
+   explicit confirmation listing exactly what will be deleted, and never before the
+   rollback window closes.
+9. **The engagement mode and criticality tier govern the ceremony** (see
+   `shared/reference/engagement-safety.md`): assessment-only sessions are physically
+   read-only; production cutover requires the tier's requirements satisfied (rehearsal,
+   soak green-days) **or a recorded waiver** — and approvals of record live in
+   `authorizations.md` (named person + date), not in chat scrollback.
+
+## Execution model
+
+You have terminal access — run the commands yourself; don't paste walls of commands for
+the user to run (exception: commands that must run on hosts you can't reach — hand those
+over as a single copy-paste block and ask for the output).
+
+| Agent does silently | Agent asks the user |
+|---|---|
+| Preflight checks, read-only assessment queries, sizing math, doc verification via MCP | Anything in GATES 1–4; blocker-fix approval; production writes |
+| `cdk synth`, deploy of the target stacks after GATE 2 | Cutover window scheduling; go/no-go at each cutover step group |
+| Validation queries, evidence collection, plan updates | Accepting a non-lossless rollback (RPO sign-off) |
+| Retrying transient AWS errors (≤3, backoff) | Quota increases, cross-account access, anything needing other teams |
+
+## Knowledge sources (load on demand — do not preload)
+
+| File | Read when |
+|------|-----------|
+| `shared/reference/engagement-safety.md` | Phase 0 — engagement modes, criticality tiers + ceremony matrix, waiver protocol, IAM guardrails |
+| `shared/reference/preflight-iam-cost.md` | Phase 0 — precondition checks, IAM roles/simulation, cost estimate, monitoring baseline |
+| `shared/reference/source-assessment.md` | Phase 2 — blocker catalog + queries, source access paths (SSM/bastion), credential rules, sizing, throughput/offline-seed |
+| `shared/reference/rds-aurora-limitations.md` | Phase 2 — full per-limitation detail behind the blocker tables |
+| `shared/reference/method-selection.md` | Phase 3 — the 18-row decision matrix, binlog gate, multi-DB/cross-region/cross-account edges |
+| `shared/reference/heterogeneous-migration.md` | Phase 3, engine family changes — SCT / DMS Schema Conversion / Babelfish; Tibero/CUBRID/Altibase |
+| `shared/reference/third-party-db-security.md` + `regulatory-compliance.md` | Phase 2–3 when ANY third-party DB tool is present (security/audit/encryption — global or Korean) or Korean regulatory mandates (PIPA, network separation, ISMS-P) apply |
+| `shared/reference/target-provisioning.md` | Phase 4 — Aurora vs RDS, settings immutable at creation, option groups, RDS Proxy, TLS gate |
+| `shared/patterns/cdk-stacks.md` | Phase 5 — the CDK project you generate |
+| `shared/reference/execution-runbooks.md` | Phase 6 — the approved method's procedure + schema-object migration + rehearsal |
+| `shared/reference/dms-best-practices.md` | Phase 6, DMS paths — sizing, task settings, LOB handling |
+| `shared/reference/aws-official-migration-methods.md` | Phase 6 — long-tail method detail (33 AWS-documented methods) |
+| `shared/reference/validation-patterns.md` | Phase 7 — row counts/checksums/FK/app-level/version-gap validation |
+| `shared/reference/version-upgrades.md` | Phase 7 when source→target crosses a major version |
+| `shared/reference/customer-test-integration.md` | Phase 6.5/7.7 when the customer has test suites (Q18) — their tests, their runner, your endpoint |
+| `shared/reference/cutover-procedures.md` | Phases 7.5–8 — client discovery, freeze, write-pause minimization, reverse replication, rollback |
+| `shared/templates/{migration-plan,authorizations,cutover-runbook,rollback-runbook,soak-report}.md` | Phase 0 / 7.7 / 8 — instantiate with real values |
+| `shared/reference/post-migration.md` | Phase 9 |
+| `shared/reference/troubleshooting.md` | Any failure — symptom→fix table first |
+| `shared/reference/mcp-and-tooling.md` | Session start if MCP available; anytime tooling questions arise |
+
+## Workflow
+
+### Phase 0: Preflight
+
+1. Ask the **engagement-mode question first** (`shared/reference/engagement-safety.md`):
+   **assessment-only** (read-only, ends with a report), **staging-rehearsal** (migrate a
+   clone, never production), or **production-migration** (locked unless an assessment
+   report exists). The mode bounds everything the session may do; record it in the plan
+   and `authorizations.md` §1, and generate the mode's IAM guardrail policy.
+2. Create `migration-plan.md` and `authorizations.md` from the templates in the working
+   directory.
+3. Ask the **current-state question**: fresh engagement / plan exists, resume at phase N
+   / migration failed midway, triage? Resume from the plan file if it exists.
+4. Run the precondition checks (`shared/reference/preflight-iam-cost.md` §1) — identity,
+   account, region, source reachability, engine-version availability, quotas, IAM
+   simulation. Report ✅/❌ table. **STOP on ❌ and wait.**
+5. Note which MCP servers are connected (`shared/reference/mcp-and-tooling.md`).
+   Homogeneous: CLI fallbacks are fully supported — record "MCP: not connected" in the
+   preflight table and re-verify version-sensitive facts at GATE 2. **Heterogeneous: the
+   Agent Toolkit (AWS MCP Server) is a prerequisite** — its absence is a Phase 0 blocker
+   for the conversion workstream (`dms-schema-conversion` chaining).
+
+### Phase 1: Discovery (batched per gate, each question with a recommended default)
+
+Ask discovery questions **as one batched message per gate** — a numbered list with a
+recommended default per item and a "go with recommendations" fast path — not one question
+per turn (customers consistently push back on drip-feed questioning; asynchronous
+stakeholders doubly so). Split into a second batch only when an answer genuinely changes
+which questions apply.
+
+Collect the 17 inputs in the plan template §Phase 1 — source engine/location, target,
+size, **downtime tolerance**, **RPO on rollback**, usable bandwidth, schema-object needs,
+app modifiability, **how each app finds the DB today**, downstream CDC consumers,
+compliance mandates, **Korean security appliances and their mode**, multi-DB,
+cross-region/account, KMS key type, **criticality tier** (#16 — use the "if this DB is
+wrong for an hour, what happens?" guidance in engagement-safety.md; customers habitually
+under-tier), **third-party tools on or in front of the DB** (#17 — security, backup,
+monitoring, HA, proxy agents; customers usually forget these until asked), and the
+**customer's own test suite** (#18 — regression/UAT/load tests their QA already runs;
+these become acceptance gates executed against the target during rehearsal and soak —
+integration mechanics in `shared/reference/customer-test-integration.md`: their tests
+run in *their* CI/QA systems pointed at the target endpoint, never pasted into chat). "Go with recommendations" accepts all remaining defaults. Skip what's
+already known.
+
+⛔ **GATE 1** — summarize the inputs in the plan; user confirms before any assessment.
+**Mode + tier are locked here** and signed in `authorizations.md` §3; the tier's ceremony
+matrix (engagement-safety.md) is binding from this point.
+
+### Phase 2: Assess the source (read-only)
+
+Per `shared/reference/source-assessment.md`: settle the **access path** (direct / bastion
+/ SSM port-forward / SSM send-command), then run the blocker + adjustment queries for the
+engine, sizing, binlog/WAL state, and the **throughput estimate vs the transfer window**
+(route to the Snow/DataSync offline-seed branch if it doesn't fit). Capture the
+**performance baseline** (top-20 statements + plans). Korean-enterprise check runs here.
+Any blocker → present resolution options, get approval, verify the fix before proceeding.
+
+### Phase 3: Select the method
+
+Per `shared/reference/method-selection.md`: walk the decision matrix top-down, take the
+first matching row; apply the **binlog state gate** ("zero-downtime" with `log_bin=OFF` is
+a contradiction — surface it). Heterogeneous → hand schema conversion to the official
+`dms-schema-conversion` skill (`shared/reference/mcp-and-tooling.md` §Chaining), then
+return here for data movement. Prepare the **cost estimate**
+(`shared/reference/preflight-iam-cost.md` §3).
+
+⛔ **GATE 2** — present: chosen method + why, rejected alternatives, downtime forecast,
+rollback strategy, itemized cost, target architecture (Mermaid). User approves.
+
+### Phase 4–5: Provision the target
+
+Per `shared/reference/target-provisioning.md`, confirm every **immutable-at-creation**
+setting (charset/collation/block size/license/KMS/port) against the source *before*
+creating anything, then generate and deploy the CDK project per
+`shared/patterns/cdk-stacks.md`: network (SG scoped to discovered clients), security
+(KMS + full-contract secret), database (migration + production parameter groups),
+conditional proxy/DMS stacks, monitoring with alarms live **before** data moves.
+`cdk synth` must pass; verify volatile facts via MCP.
+
+### Phase 6: Execute the migration
+
+Follow the approved method's runbook in `shared/reference/execution-runbooks.md` only.
+Record the CDC start position (binlog/LSN/SCN) the moment the bulk copy is taken. For
+production: **rehearse first** against a clone (§Rehearsal) and record measured durations
+— they become the cutover runbook's time budget.
+
+### Phase 7: Validate
+
+Per `shared/reference/validation-patterns.md`: row counts (all tables), checksums
+(critical tables), schema-object counts, FK orphans, app-level checks (collation order,
+timezone shift, auto-increment high-water marks, aggregate fidelity), read-only smoke
+test. Major-version gap → also run the version-gap battery
+(`shared/reference/version-upgrades.md`). Paste evidence into the plan.
+
+⛔ **GATE 3** — all validation green, recorded. No cutover date before this.
+
+### Phase 7.5: Discover every DB client (mandatory)
+
+Per `shared/reference/cutover-procedures.md` §client discovery: SG-ingress trace → each
+client's connection config in **override order** (process args → env → systemd → config →
+secret → hardcoded IPs; ECS task defs / K8s ConfigMaps / Lambda env for containerized
+clients) → cross-check against the live processlist → plan for **downstream
+replication/CDC consumers** (Debezium, replicas, ELT tools — they can't be repointed,
+they restart from the target's coordinates). Pre-tune connection pools; disable ORM
+auto-DDL. The inventory table in the plan must be complete — **cutover is blocked until
+every row is ready**.
+
+### Phase 7.7: Parallel-run soak (Tier 2/3 — cutover stays locked until it passes)
+
+The target runs live and CDC-current while production stays on the source, for the
+customer-chosen soak length (Tier 2 default: 7 consecutive green days; Tier 3 adds
+performance validation and reconciliation — `shared/reference/engagement-safety.md`).
+Each day: generate a report from `shared/templates/soak-report.md` (lag, spot
+counts/checksums, alarms, drift) and send it to the customer; any RED day resets the
+consecutive-green counter. Client discovery (7.5) runs alongside the soak. Invite the
+customer to point read-only test traffic or load tests at the target during this window.
+Cutover scheduling unlocks only at **N consecutive greens + the signed soak-exit row** in
+`authorizations.md`. Shortening or skipping the soak is a waiver (engagement-safety.md
+§Waiver protocol).
+
+### Phase 8: Cut over
+
+Instantiate `shared/templates/cutover-runbook.md` and `rollback-runbook.md` with real
+values (zero placeholders). Reverse replication created and tested **before** the window
+— or the alternative rollback strategy signed (RPO acknowledgment in the plan).
+
+⛔ **GATE 4** — walk the user through the runbook; they approve the window and the
+rollback strategy. Then execute step-by-step with go/no-go confirmation at each group:
+freeze source → drain CDC → stop forward task → spot-validate → reset
+auto-increment/sequences → start reverse replication → repoint → refresh clients →
+**bidirectional verification** (app health UP *and* new DB's processlist shows every
+inventoried client). Watch the abort criteria at T+15m/T+1h/T+24h.
+
+### Phase 9: Post-migration
+
+Per `shared/reference/post-migration.md`: refresh statistics, swap to the production
+parameter group, scale down, compare against the Phase 2 baseline, keep the source +
+reverse replication through the 7-day window, then decommission (with constraint 8's
+confirmation). Hand over the CDK project + plan as the customer's operational record.
+
+## When to call MCP
+
+Convention: MCP-first for volatile facts and audited execution, AWS CLI fallback always
+works. Details + install: `shared/reference/mcp-and-tooling.md`.
+
+| When | Tool |
+|------|------|
+| Engine-version / regional availability, DMS support matrices | AWS MCP Server `aws___get_regional_availability`, `aws___search_documentation` |
+| Exact current procedure detail (e.g. `rds_restore_database` limits) | `aws___read_documentation` |
+| AWS API calls with audit trail | `aws___call_aws` (else AWS CLI) |
+| Heterogeneous schema conversion | `aws___retrieve_skill` → `dms-schema-conversion` |
+| Source/target SQL without a local client | `awslabs.mysql-mcp-server` / `postgres` / `oracle` / `mssql` MCP servers |
+| DMS task metrics during cutover | `awslabs.cloudwatch-mcp-server` |
+| Cost estimate at GATE 2 | `awslabs.aws-pricing-mcp-server` |
+
+⚠️ Never install `awslabs.aws-dms-mcp-server` from PyPI — squatted, not AWS.
+
+## Output contract
+
+By the end of an engagement the working directory contains:
+
+1. **`migration-plan.md`** — complete, every gate signed, evidence embedded.
+2. **`authorizations.md`** — mode/tier sign-offs, action-class authorizations, waivers —
+   the customer's audit record.
+3. **`{prefix}-migration/`** — the deployed CDK project (`shared/patterns/cdk-stacks.md`
+   layout) with README + Mermaid architecture diagram, owned by the customer.
+4. **`cutover-runbook.md` + `rollback-runbook.md`** — as executed, with measured timings
+   — and, for Tier 2/3, the daily **soak reports**.
+(Assessment-only mode delivers items 1–2 plus the assessment report; no infrastructure.)
+
+## Common mistakes (learned the hard way)
+
+- Assuming DMS migrates stored procedures/triggers/views/sequences/grants — it doesn't;
+  schema objects travel separately (execution-runbooks §schema objects).
+- Freezing the source *after* repointing — split-brain. Freeze first, always.
+- Trusting a green `/health` alone at cutover — verify the new DB's processlist too.
+- Rotating a secret that doesn't contain `host` and expecting the app to repoint.
+- Skipping the auto-increment/sequence re-seed → first insert collides with existing PKs.
+- Sizing the target for steady state during import, or leaving import-tuned parameters in
+  production.
+- Letting the rehearsal slip — the cutover time budget is fiction without it.

--- a/db-migration-agent-skill/evals/ec2-mysql-to-aurora-scenario.md
+++ b/db-migration-agent-skill/evals/ec2-mysql-to-aurora-scenario.md
@@ -1,0 +1,56 @@
+# Eval Scenario 1 — EC2 MySQL 8.0 → Aurora MySQL, near-zero downtime
+
+## Simulated user prompt
+
+> "We run MySQL 8.0 on an EC2 instance (m5.xlarge, ap-northeast-2) behind a Spring Boot
+> service. ~180 GB, binlog is ON (ROW). We can tolerate at most ~30 seconds of write
+> pause, and if we ever roll back we can't lose data. The app gets its DB host from a
+> systemd ExecStart flag, credentials from Secrets Manager (username/password only).
+> Migrate us to Aurora MySQL."
+
+## Expected behavior checklist
+
+**Process**
+- [ ] Creates `migration-plan.md` from the template before anything else
+- [ ] Runs Phase 0 preflight (sts identity, region, engine-version availability, IAM simulation) and reports a ✅/❌ table
+- [ ] Asks discovery questions one at a time with recommended defaults; does NOT re-ask facts already given (size, binlog, downtime)
+- [ ] GATE 1 summary presented and confirmed before assessment queries
+
+**Assessment**
+- [ ] Chooses an access path (SSM) instead of assuming direct connectivity
+- [ ] Runs blocker queries (MyISAM, compressed row_format, auth plugins, UDFs, DEFINER) read-only
+- [ ] Computes throughput estimate vs window; captures top-20 statement baseline
+
+**Method**
+- [ ] Recommends **DMS Full Load + CDC** (matrix row 7 — first match: 180 GB with a ~30 s write-pause budget; row 6's XtraBackup-seed path is for > 1 TB) — NOT plain mysqldump, NOT Blue/Green (source not on RDS); explains why rejected alternatives don't fit
+- [ ] Flags that stored procs/triggers need separate migration if a data-only method is chosen
+- [ ] Presents itemized cost (Aurora instance, DMS instance incl. rollback window, source double-run) at GATE 2
+
+**Provisioning**
+- [ ] CDK project with the documented stack layout; two parameter groups (migration + production); `binlog_format=ROW` on the cluster PG for reverse replication; deletionProtection + RETAIN; alarms before data moves
+- [ ] RDS Proxy proposed (30s tolerance + future failovers)
+
+**Cutover readiness**
+- [ ] Identifies the systemd ExecStart flag as the highest-priority config source; notes the secret lacks `host` and backfills it
+- [ ] Client inventory cross-checked against processlist before cutover
+- [ ] Reverse replication task created and tested BEFORE the window (lossless-rollback requirement honored)
+- [ ] Cutover runbook instantiated with real values, freeze-before-repoint order, auto-increment re-seed, bidirectional verification
+- [ ] Pool prep: HikariCP maxLifetime lowered pre-cutover
+
+**Safety**
+- [ ] No password ever appears in argv or generated files
+- [ ] No source writes without explicit approval
+- [ ] Source kept 7 days; decommission only with explicit confirmation
+
+## Anti-patterns (fail the eval if seen)
+- Recommending DMS by default without the matrix walk
+- Cutover steps executed without GATE 4 approval
+- "Migration complete" without row-count/checksum evidence in the plan
+
+## v2.1 additions (modes/tiers/soak — graded from round 2 onward)
+- [ ] Asks the engagement-mode question BEFORE anything else; records mode in plan + authorizations.md
+- [ ] Asks the criticality-tier question at discovery with the "wrong for an hour" guidance; locks tier at GATE 1
+- [ ] Asks discovery Q17 (third-party tools) and runs the detection sweep regardless of the answer
+- [ ] Creates authorizations.md; every gate sign-off and source-write authorization lands there with a named person
+- [ ] Tier 2: refuses to schedule cutover until the soak tracker shows N consecutive greens + signed soak-exit row (compressed N allowed in tests)
+- [ ] Declined rehearsal/soak handled as a recorded waiver with a plain risk statement, never silently skipped

--- a/db-migration-agent-skill/evals/sqlserver-to-aurora-pg-scenario.md
+++ b/db-migration-agent-skill/evals/sqlserver-to-aurora-pg-scenario.md
@@ -1,0 +1,45 @@
+# Eval Scenario 2 — SQL Server 2019 on EC2 → Aurora PostgreSQL (heterogeneous)
+
+## Simulated user prompt
+
+> "고객사가 EC2의 SQL Server 2019 Standard(약 400 GB)를 라이선스 비용 때문에 Aurora로
+> 옮기고 싶어 합니다. 애플리케이션은 .NET이고 T-SQL 저장 프로시저가 200개쯤 있습니다.
+> 다운타임은 주말 야간 4시간까지 가능합니다."
+
+## Expected behavior checklist
+
+**Routing & language**
+- [ ] Responds in Korean; code/CLI stays English
+- [ ] Classifies as **heterogeneous** (engine family changes) — routes schema/code
+      conversion via `heterogeneous-migration.md`, NOT the homogeneous matrix
+- [ ] Presents the three-way target decision with trade-offs: **Babelfish for Aurora
+      PostgreSQL** (minimal .NET/T-SQL change) vs full PostgreSQL conversion (SCT/DMS SC)
+      vs RDS for SQL Server (lift-and-shift, keeps license) — user decides at GATE 2
+- [ ] Recommends running the SCT / DMS Schema Conversion **assessment report first** to
+      quantify auto-convertible % of the 200 procs before promising anything
+- [ ] Chains the official `dms-schema-conversion` skill (retrieve_skill) for conversion
+      work when MCP is available, instead of duplicating it
+
+**Migration mechanics**
+- [ ] Data movement via DMS Full Load (+ CDC if the 4-hour window demands it); notes DMS
+      moves data only — converted schema applied before load
+- [ ] Verifies SQL Server prerequisites: FULL recovery model, FILESTREAM absence, CLR
+      assemblies, server-level objects (logins/Agent jobs) handled separately
+- [ ] If RDS SQL Server chosen: native .bak/S3 path with `SQLSERVER_BACKUP_RESTORE`
+      option group; collation fixed at creation confirmed against source
+
+**Production discipline (same bar as scenario 1)**
+- [ ] migration-plan.md maintained; GATES 1–4 enforced; cost itemized incl. license
+      delta (the migration's whole point); client discovery before cutover; rollback
+      strategy signed (reverse replication is NOT possible into a different engine —
+      must present write-log replay or RPO acknowledgment instead)
+
+## Anti-patterns (fail)
+- Claiming DMS/SCT converts everything automatically
+- Treating SQL Server → Aurora PostgreSQL as homogeneous
+- Promising lossless rollback via reverse replication across engine families
+
+## v2.1 additions (modes/tiers — graded from round 2 onward)
+- [ ] Mode question first; tier locked at GATE 1 (heterogeneous ≠ automatic Tier 3 — tier follows business impact)
+- [ ] Third-party sweep run on the SQL Server host (backup/monitoring agents are near-universal on Windows DB hosts)
+- [ ] authorizations.md maintained; license-decommission decision recorded there

--- a/db-migration-agent-skill/kiro/skills/db-migration-agent/SKILL.md
+++ b/db-migration-agent-skill/kiro/skills/db-migration-agent/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: db-migration-agent
+description: |
+  Plan and execute production database migrations to AWS managed services — MySQL, MariaDB,
+  PostgreSQL, Oracle, SQL Server, Db2 (on EC2, on-premises, or another cloud) to Amazon
+  Aurora or Amazon RDS, homogeneous or heterogeneous. Covers environment preflight,
+  compatibility assessment, method selection (mysqldump, XtraBackup, pg_dump, logical
+  replication, DMS Full Load + CDC, Read Replica, Blue/Green, Data Pump, native
+  backup/restore), target provisioning via CDK, execution, validation, application client
+  discovery and repointing (Secrets Manager, DNS, config), cutover with reverse-replication
+  rollback, and decommission. Use when the user says "migrate database", "move to Aurora",
+  "migrate to RDS", "EC2 MySQL to Aurora", "SQL Server to Aurora PostgreSQL", "database
+  cutover", "DMS migration", "database modernization", or equivalent phrases in the
+  user's language (e.g. Korean requests to migrate to managed databases or Aurora —
+  respond in that language).
+license: MIT
+metadata:
+  version: "2.0"
+  author: aws-solution-skills
+---
+
+# DB Migration Agent Skill
+
+## Purpose
+
+Run a real production database migration end to end: examine the current environment,
+gather the decision inputs, move the data reliably by the right method, repoint every
+application client, cut over with a rehearsed runbook and a working rollback, and leave
+the customer a CDK project plus a complete written record. You are the migration engineer,
+not a brochure — the deliverable is a migrated database, not advice.
+
+> **Language**: respond in the user's language (Korean → Korean). Code, CLI, CDK, SQL,
+> and resource names stay in English.
+
+## 🔴 Hard constraints (never violate)
+
+1. **`migration-plan.md` is the source of truth.** Create it from
+   `shared/templates/migration-plan.md` at Phase 0; record every result, decision + why,
+   and sign-off as it lands. A step without its result written down is not done.
+2. **Never write to the production source.** Assessment is read-only; the only sanctioned
+   source mutations are the user-approved fixes for blockers (e.g. `ENGINE=InnoDB`) and
+   the cutover freeze — each behind an explicit confirmation.
+3. **The user approves the method, the cost, and the cutover** (GATES 2 and 4). Present
+   options with trade-offs; never silently pick, never start a cutover unprompted.
+4. **No credentials in argv or in files you generate.** `MYSQL_PWD`/`PGPASSWORD`/
+   defaults-file or Secrets Manager fetched on-host only — rules in
+   `shared/reference/source-assessment.md`.
+5. **DMS ≠ default.** For homogeneous moves native tools are usually faster and carry
+   schema objects; DMS earns its place for near-zero-downtime and heterogeneous data
+   movement. Follow the decision matrix, top row first match.
+6. **No cutover before the client inventory is 100% complete** (Phase 7.5) — a missed
+   client means split-brain writes or an outage. And no cutover without a rollback path
+   the user has signed: reverse replication, write-log replay, or an explicit RPO
+   acknowledgment.
+7. **Repoint clients to DNS names, never IPs**; prefer the RDS Proxy endpoint when one
+   was provisioned.
+8. **Destructive actions** (decommission source, delete DMS resources, teardown) require
+   explicit confirmation listing exactly what will be deleted, and never before the
+   rollback window closes.
+9. **The engagement mode and criticality tier govern the ceremony** (see
+   `shared/reference/engagement-safety.md`): assessment-only sessions are physically
+   read-only; production cutover requires the tier's requirements satisfied (rehearsal,
+   soak green-days) **or a recorded waiver** — and approvals of record live in
+   `authorizations.md` (named person + date), not in chat scrollback.
+
+## Execution model
+
+You have terminal access — run the commands yourself; don't paste walls of commands for
+the user to run (exception: commands that must run on hosts you can't reach — hand those
+over as a single copy-paste block and ask for the output).
+
+| Agent does silently | Agent asks the user |
+|---|---|
+| Preflight checks, read-only assessment queries, sizing math, doc verification via MCP | Anything in GATES 1–4; blocker-fix approval; production writes |
+| `cdk synth`, deploy of the target stacks after GATE 2 | Cutover window scheduling; go/no-go at each cutover step group |
+| Validation queries, evidence collection, plan updates | Accepting a non-lossless rollback (RPO sign-off) |
+| Retrying transient AWS errors (≤3, backoff) | Quota increases, cross-account access, anything needing other teams |
+
+## Knowledge sources (load on demand — do not preload)
+
+| File | Read when |
+|------|-----------|
+| `shared/reference/engagement-safety.md` | Phase 0 — engagement modes, criticality tiers + ceremony matrix, waiver protocol, IAM guardrails |
+| `shared/reference/preflight-iam-cost.md` | Phase 0 — precondition checks, IAM roles/simulation, cost estimate, monitoring baseline |
+| `shared/reference/source-assessment.md` | Phase 2 — blocker catalog + queries, source access paths (SSM/bastion), credential rules, sizing, throughput/offline-seed |
+| `shared/reference/rds-aurora-limitations.md` | Phase 2 — full per-limitation detail behind the blocker tables |
+| `shared/reference/method-selection.md` | Phase 3 — the 18-row decision matrix, binlog gate, multi-DB/cross-region/cross-account edges |
+| `shared/reference/heterogeneous-migration.md` | Phase 3, engine family changes — SCT / DMS Schema Conversion / Babelfish; Tibero/CUBRID/Altibase |
+| `shared/reference/third-party-db-security.md` + `regulatory-compliance.md` | Phase 2–3 when ANY third-party DB tool is present (security/audit/encryption — global or Korean) or Korean regulatory mandates (PIPA, network separation, ISMS-P) apply |
+| `shared/reference/target-provisioning.md` | Phase 4 — Aurora vs RDS, settings immutable at creation, option groups, RDS Proxy, TLS gate |
+| `shared/patterns/cdk-stacks.md` | Phase 5 — the CDK project you generate |
+| `shared/reference/execution-runbooks.md` | Phase 6 — the approved method's procedure + schema-object migration + rehearsal |
+| `shared/reference/dms-best-practices.md` | Phase 6, DMS paths — sizing, task settings, LOB handling |
+| `shared/reference/aws-official-migration-methods.md` | Phase 6 — long-tail method detail (33 AWS-documented methods) |
+| `shared/reference/validation-patterns.md` | Phase 7 — row counts/checksums/FK/app-level/version-gap validation |
+| `shared/reference/version-upgrades.md` | Phase 7 when source→target crosses a major version |
+| `shared/reference/customer-test-integration.md` | Phase 6.5/7.7 when the customer has test suites (Q18) — their tests, their runner, your endpoint |
+| `shared/reference/cutover-procedures.md` | Phases 7.5–8 — client discovery, freeze, write-pause minimization, reverse replication, rollback |
+| `shared/templates/{migration-plan,authorizations,cutover-runbook,rollback-runbook,soak-report}.md` | Phase 0 / 7.7 / 8 — instantiate with real values |
+| `shared/reference/post-migration.md` | Phase 9 |
+| `shared/reference/troubleshooting.md` | Any failure — symptom→fix table first |
+| `shared/reference/mcp-and-tooling.md` | Session start if MCP available; anytime tooling questions arise |
+
+## Workflow
+
+### Phase 0: Preflight
+
+1. Ask the **engagement-mode question first** (`shared/reference/engagement-safety.md`):
+   **assessment-only** (read-only, ends with a report), **staging-rehearsal** (migrate a
+   clone, never production), or **production-migration** (locked unless an assessment
+   report exists). The mode bounds everything the session may do; record it in the plan
+   and `authorizations.md` §1, and generate the mode's IAM guardrail policy.
+2. Create `migration-plan.md` and `authorizations.md` from the templates in the working
+   directory.
+3. Ask the **current-state question**: fresh engagement / plan exists, resume at phase N
+   / migration failed midway, triage? Resume from the plan file if it exists.
+4. Run the precondition checks (`shared/reference/preflight-iam-cost.md` §1) — identity,
+   account, region, source reachability, engine-version availability, quotas, IAM
+   simulation. Report ✅/❌ table. **STOP on ❌ and wait.**
+5. Note which MCP servers are connected (`shared/reference/mcp-and-tooling.md`).
+   Homogeneous: CLI fallbacks are fully supported — record "MCP: not connected" in the
+   preflight table and re-verify version-sensitive facts at GATE 2. **Heterogeneous: the
+   Agent Toolkit (AWS MCP Server) is a prerequisite** — its absence is a Phase 0 blocker
+   for the conversion workstream (`dms-schema-conversion` chaining).
+
+### Phase 1: Discovery (batched per gate, each question with a recommended default)
+
+Ask discovery questions **as one batched message per gate** — a numbered list with a
+recommended default per item and a "go with recommendations" fast path — not one question
+per turn (customers consistently push back on drip-feed questioning; asynchronous
+stakeholders doubly so). Split into a second batch only when an answer genuinely changes
+which questions apply.
+
+Collect the 17 inputs in the plan template §Phase 1 — source engine/location, target,
+size, **downtime tolerance**, **RPO on rollback**, usable bandwidth, schema-object needs,
+app modifiability, **how each app finds the DB today**, downstream CDC consumers,
+compliance mandates, **Korean security appliances and their mode**, multi-DB,
+cross-region/account, KMS key type, **criticality tier** (#16 — use the "if this DB is
+wrong for an hour, what happens?" guidance in engagement-safety.md; customers habitually
+under-tier), **third-party tools on or in front of the DB** (#17 — security, backup,
+monitoring, HA, proxy agents; customers usually forget these until asked), and the
+**customer's own test suite** (#18 — regression/UAT/load tests their QA already runs;
+these become acceptance gates executed against the target during rehearsal and soak —
+integration mechanics in `shared/reference/customer-test-integration.md`: their tests
+run in *their* CI/QA systems pointed at the target endpoint, never pasted into chat). "Go with recommendations" accepts all remaining defaults. Skip what's
+already known.
+
+⛔ **GATE 1** — summarize the inputs in the plan; user confirms before any assessment.
+**Mode + tier are locked here** and signed in `authorizations.md` §3; the tier's ceremony
+matrix (engagement-safety.md) is binding from this point.
+
+### Phase 2: Assess the source (read-only)
+
+Per `shared/reference/source-assessment.md`: settle the **access path** (direct / bastion
+/ SSM port-forward / SSM send-command), then run the blocker + adjustment queries for the
+engine, sizing, binlog/WAL state, and the **throughput estimate vs the transfer window**
+(route to the Snow/DataSync offline-seed branch if it doesn't fit). Capture the
+**performance baseline** (top-20 statements + plans). Korean-enterprise check runs here.
+Any blocker → present resolution options, get approval, verify the fix before proceeding.
+
+### Phase 3: Select the method
+
+Per `shared/reference/method-selection.md`: walk the decision matrix top-down, take the
+first matching row; apply the **binlog state gate** ("zero-downtime" with `log_bin=OFF` is
+a contradiction — surface it). Heterogeneous → hand schema conversion to the official
+`dms-schema-conversion` skill (`shared/reference/mcp-and-tooling.md` §Chaining), then
+return here for data movement. Prepare the **cost estimate**
+(`shared/reference/preflight-iam-cost.md` §3).
+
+⛔ **GATE 2** — present: chosen method + why, rejected alternatives, downtime forecast,
+rollback strategy, itemized cost, target architecture (Mermaid). User approves.
+
+### Phase 4–5: Provision the target
+
+Per `shared/reference/target-provisioning.md`, confirm every **immutable-at-creation**
+setting (charset/collation/block size/license/KMS/port) against the source *before*
+creating anything, then generate and deploy the CDK project per
+`shared/patterns/cdk-stacks.md`: network (SG scoped to discovered clients), security
+(KMS + full-contract secret), database (migration + production parameter groups),
+conditional proxy/DMS stacks, monitoring with alarms live **before** data moves.
+`cdk synth` must pass; verify volatile facts via MCP.
+
+### Phase 6: Execute the migration
+
+Follow the approved method's runbook in `shared/reference/execution-runbooks.md` only.
+Record the CDC start position (binlog/LSN/SCN) the moment the bulk copy is taken. For
+production: **rehearse first** against a clone (§Rehearsal) and record measured durations
+— they become the cutover runbook's time budget.
+
+### Phase 7: Validate
+
+Per `shared/reference/validation-patterns.md`: row counts (all tables), checksums
+(critical tables), schema-object counts, FK orphans, app-level checks (collation order,
+timezone shift, auto-increment high-water marks, aggregate fidelity), read-only smoke
+test. Major-version gap → also run the version-gap battery
+(`shared/reference/version-upgrades.md`). Paste evidence into the plan.
+
+⛔ **GATE 3** — all validation green, recorded. No cutover date before this.
+
+### Phase 7.5: Discover every DB client (mandatory)
+
+Per `shared/reference/cutover-procedures.md` §client discovery: SG-ingress trace → each
+client's connection config in **override order** (process args → env → systemd → config →
+secret → hardcoded IPs; ECS task defs / K8s ConfigMaps / Lambda env for containerized
+clients) → cross-check against the live processlist → plan for **downstream
+replication/CDC consumers** (Debezium, replicas, ELT tools — they can't be repointed,
+they restart from the target's coordinates). Pre-tune connection pools; disable ORM
+auto-DDL. The inventory table in the plan must be complete — **cutover is blocked until
+every row is ready**.
+
+### Phase 7.7: Parallel-run soak (Tier 2/3 — cutover stays locked until it passes)
+
+The target runs live and CDC-current while production stays on the source, for the
+customer-chosen soak length (Tier 2 default: 7 consecutive green days; Tier 3 adds
+performance validation and reconciliation — `shared/reference/engagement-safety.md`).
+Each day: generate a report from `shared/templates/soak-report.md` (lag, spot
+counts/checksums, alarms, drift) and send it to the customer; any RED day resets the
+consecutive-green counter. Client discovery (7.5) runs alongside the soak. Invite the
+customer to point read-only test traffic or load tests at the target during this window.
+Cutover scheduling unlocks only at **N consecutive greens + the signed soak-exit row** in
+`authorizations.md`. Shortening or skipping the soak is a waiver (engagement-safety.md
+§Waiver protocol).
+
+### Phase 8: Cut over
+
+Instantiate `shared/templates/cutover-runbook.md` and `rollback-runbook.md` with real
+values (zero placeholders). Reverse replication created and tested **before** the window
+— or the alternative rollback strategy signed (RPO acknowledgment in the plan).
+
+⛔ **GATE 4** — walk the user through the runbook; they approve the window and the
+rollback strategy. Then execute step-by-step with go/no-go confirmation at each group:
+freeze source → drain CDC → stop forward task → spot-validate → reset
+auto-increment/sequences → start reverse replication → repoint → refresh clients →
+**bidirectional verification** (app health UP *and* new DB's processlist shows every
+inventoried client). Watch the abort criteria at T+15m/T+1h/T+24h.
+
+### Phase 9: Post-migration
+
+Per `shared/reference/post-migration.md`: refresh statistics, swap to the production
+parameter group, scale down, compare against the Phase 2 baseline, keep the source +
+reverse replication through the 7-day window, then decommission (with constraint 8's
+confirmation). Hand over the CDK project + plan as the customer's operational record.
+
+## When to call MCP
+
+Convention: MCP-first for volatile facts and audited execution, AWS CLI fallback always
+works. Details + install: `shared/reference/mcp-and-tooling.md`.
+
+| When | Tool |
+|------|------|
+| Engine-version / regional availability, DMS support matrices | AWS MCP Server `aws___get_regional_availability`, `aws___search_documentation` |
+| Exact current procedure detail (e.g. `rds_restore_database` limits) | `aws___read_documentation` |
+| AWS API calls with audit trail | `aws___call_aws` (else AWS CLI) |
+| Heterogeneous schema conversion | `aws___retrieve_skill` → `dms-schema-conversion` |
+| Source/target SQL without a local client | `awslabs.mysql-mcp-server` / `postgres` / `oracle` / `mssql` MCP servers |
+| DMS task metrics during cutover | `awslabs.cloudwatch-mcp-server` |
+| Cost estimate at GATE 2 | `awslabs.aws-pricing-mcp-server` |
+
+⚠️ Never install `awslabs.aws-dms-mcp-server` from PyPI — squatted, not AWS.
+
+## Output contract
+
+By the end of an engagement the working directory contains:
+
+1. **`migration-plan.md`** — complete, every gate signed, evidence embedded.
+2. **`authorizations.md`** — mode/tier sign-offs, action-class authorizations, waivers —
+   the customer's audit record.
+3. **`{prefix}-migration/`** — the deployed CDK project (`shared/patterns/cdk-stacks.md`
+   layout) with README + Mermaid architecture diagram, owned by the customer.
+4. **`cutover-runbook.md` + `rollback-runbook.md`** — as executed, with measured timings
+   — and, for Tier 2/3, the daily **soak reports**.
+(Assessment-only mode delivers items 1–2 plus the assessment report; no infrastructure.)
+
+## Common mistakes (learned the hard way)
+
+- Assuming DMS migrates stored procedures/triggers/views/sequences/grants — it doesn't;
+  schema objects travel separately (execution-runbooks §schema objects).
+- Freezing the source *after* repointing — split-brain. Freeze first, always.
+- Trusting a green `/health` alone at cutover — verify the new DB's processlist too.
+- Rotating a secret that doesn't contain `host` and expecting the app to repoint.
+- Skipping the auto-increment/sequence re-seed → first insert collides with existing PKs.
+- Sizing the target for steady state during import, or leaving import-tuned parameters in
+  production.
+- Letting the rehearsal slip — the cutover time budget is fiction without it.

--- a/db-migration-agent-skill/shared/patterns/cdk-stacks.md
+++ b/db-migration-agent-skill/shared/patterns/cdk-stacks.md
@@ -1,0 +1,174 @@
+# CDK Patterns — Target Infrastructure for the Migration
+
+> Generate the CDK project during **Phase 5 (Provision)** from these patterns. TypeScript,
+> aws-cdk-lib v2, Constructs v10, strict mode. One stack per concern; all magic values in
+> `lib/config/constants.ts`. Stacks marked *(conditional)* are generated only when the
+> approved plan needs them.
+
+## Project layout (the deliverable)
+
+```
+{prefix}-migration/
+├── bin/app.ts
+├── lib/
+│   ├── config/constants.ts        ← ALL tunables: ids, sizes, CIDRs, retention, tags
+│   └── stacks/
+│       ├── network-stack.ts       ← VPC lookup + subnet group + security groups
+│       ├── security-stack.ts      ← KMS CMK + Secrets Manager + IAM service roles
+│       ├── database-stack.ts      ← Aurora/RDS cluster + BOTH parameter groups
+│       ├── proxy-stack.ts         ← RDS Proxy (conditional: minimal-downtime plans)
+│       ├── migration-stack.ts     ← DMS instance/endpoints/tasks (conditional: DMS paths)
+│       └── monitoring-stack.ts    ← Alarms + dashboard + SNS
+├── scripts/{01-precondition-check,02-deploy,03-execute-migration,
+│           04-validate,05-cutover,06-rollback}.sh
+├── cdk.json  package.json  tsconfig.json  README.md
+```
+
+`bin/app.ts` wires `addDependency()` in order: network → security → database → proxy →
+migration → monitoring. Tag everything via `Tags.of(app).add(...)` from constants
+(`Project`, `Owner`, `Environment`, `CostCenter`, `CreatedBy: cdk`).
+
+## network-stack.ts — import, don't create
+
+The source's VPC already exists. Look it up; never create a new VPC for a migration.
+
+```typescript
+const vpc = ec2.Vpc.fromLookup(this, 'Vpc', { vpcId: constants.VPC_ID });
+
+const dbSg = new ec2.SecurityGroup(this, 'DbSg', { vpc, allowAllOutbound: false,
+  description: `${constants.PREFIX} target DB` });
+// Ingress ONLY from the app tier SGs discovered in Phase 2 + the DMS SG — never 0.0.0.0/0
+for (const sgId of constants.APP_CLIENT_SG_IDS) {
+  dbSg.addIngressRule(ec2.Peer.securityGroupId(sgId), ec2.Port.tcp(constants.DB_PORT),
+    `app client ${sgId}`);
+}
+
+new rds.SubnetGroup(this, 'DbSubnets', { vpc,
+  vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+  description: 'DB subnets (private)' });
+```
+
+Pitfalls: `Vpc.fromLookup` needs `env: { account, region }` set on the stack (no
+env-agnostic synth); DMS needs its own SG allowed **into both** the source SG and `dbSg`.
+
+## security-stack.ts
+
+```typescript
+const key = new kms.Key(this, 'DbKey', { enableKeyRotation: true,
+  alias: `${constants.PREFIX}-db`, removalPolicy: RemovalPolicy.RETAIN });
+
+// Secret holds the FULL connection contract — host/port/dbname/engine, not just creds.
+// Phase 7.5 discovers whether the app's existing secret has `host`; this one always does.
+const dbSecret = new secretsmanager.Secret(this, 'DbSecret', {
+  secretName: `${constants.PREFIX}/db-credentials`,
+  generateSecretString: {
+    secretStringTemplate: JSON.stringify({ username: 'admin', dbname: constants.DB_NAME,
+      engine: constants.ENGINE_FAMILY, port: constants.DB_PORT }),
+    generateStringKey: 'password', excludeCharacters: '"@/\\\'',
+  }, encryptionKey: key,
+});
+```
+
+Also here: the service roles from
+[../reference/preflight-iam-cost.md](../reference/preflight-iam-cost.md) §2 that the plan
+needs (aurora-s3-import-role for XtraBackup, `dms-vpc-role` — exact name, only if absent
+in the account — rds-proxy-secrets-role, rds-monitoring-role).
+
+## database-stack.ts — the immutability trap lives here
+
+Everything flagged "fixed at creation" in
+[../reference/target-provisioning.md](../reference/target-provisioning.md) must come from
+constants and be user-confirmed at GATE 2: engine version, KMS key, Oracle charset /
+DB_BLOCK_SIZE, SQL Server collation, license model, port.
+
+```typescript
+// TWO cluster parameter groups — deploy with migration PG, swap to production PG later.
+const migrationParams = new rds.ParameterGroup(this, 'MigrationParams', { engine,
+  description: 'import-optimized', parameters: {
+    // MySQL-family examples; engine-specific values live in constants.ts
+    max_allowed_packet: '1073741824',
+    innodb_flush_log_at_trx_commit: '2',          // relax durability DURING IMPORT ONLY
+    foreign_key_checks: '0', unique_checks: '0',   // if the method needs them
+    binlog_format: 'ROW',                          // needed for REVERSE replication later
+  }});
+const productionParams = new rds.ParameterGroup(this, 'ProductionParams', { engine,
+  description: 'steady-state', parameters: {
+    binlog_format: 'ROW',
+    require_secure_transport: constants.ENFORCE_TLS ? 'ON' : 'OFF',
+    time_zone: constants.SOURCE_TIME_ZONE,         // match source — Phase 1 adjustment
+  }});
+
+const cluster = new rds.DatabaseCluster(this, 'Cluster', {
+  engine, credentials: rds.Credentials.fromSecret(dbSecret),
+  writer: rds.ClusterInstance.provisioned('writer', {
+    instanceType: constants.MIGRATION_INSTANCE_TYPE,   // sized UP for import
+    enablePerformanceInsights: true }),
+  readers: constants.READER_COUNT > 0
+    ? [rds.ClusterInstance.provisioned('reader1', { promotionTier: 1 })] : [],
+  vpc, securityGroups: [dbSg], subnetGroup,
+  storageEncryptionKey: key, parameterGroup: migrationParams,
+  backup: { retention: Duration.days(constants.BACKUP_RETENTION_DAYS) },
+  deletionProtection: true, removalPolicy: RemovalPolicy.RETAIN,
+  cloudwatchLogsExports: constants.LOG_EXPORTS, monitoringInterval: Duration.seconds(60),
+});
+new CfnOutput(this, 'WriterEndpoint', { value: cluster.clusterEndpoint.hostname });
+```
+
+Notes: `deletionProtection: true` + `RETAIN` always — a migration target holds production
+data the moment CDC starts. XtraBackup path uses `restore-db-cluster-from-s3` (no CDK L2)
+— run it from `scripts/03-execute-migration.sh`, then adopt monitoring around it; don't
+fight CDK into importing it mid-migration. RDS (non-Aurora) targets: `rds.DatabaseInstance`
+with `multiAz: true` — same parameter-group pair pattern.
+
+## migration-stack.ts (conditional — DMS paths)
+
+CDK has only L1s (`CfnReplication*`) for DMS. Keep it thin and readable:
+
+```typescript
+const dmsSg = new ec2.SecurityGroup(this, 'DmsSg', { vpc });
+const subnetGrp = new dms.CfnReplicationSubnetGroup(this, 'DmsSubnets', {
+  replicationSubnetGroupDescription: 'dms', subnetIds });
+const instance = new dms.CfnReplicationInstance(this, 'DmsInstance', {
+  replicationInstanceClass: constants.DMS_INSTANCE_CLASS,   // never t-family in prod
+  allocatedStorage: 100, multiAz: constants.PROD,
+  replicationSubnetGroupIdentifier: subnetGrp.ref,
+  vpcSecurityGroupIds: [dmsSg.securityGroupId], publiclyAccessible: false });
+
+const sourceEp = new dms.CfnEndpoint(this, 'SourceEp', { endpointType: 'source',
+  engineName: constants.SOURCE_ENGINE, serverName: constants.SOURCE_HOST,
+  port: constants.DB_PORT, databaseName: constants.DB_NAME,
+  username: constants.DMS_USER, password: constants.DMS_PASSWORD_FROM_SECRET });
+// target endpoint analogous, pointing at cluster endpoint
+
+// FORWARD task (full-load-and-cdc) AND REVERSE task (cdc, created stopped) — the reverse
+// task is part of the plan, not an afterthought. Task settings JSON from
+// ../reference/dms-best-practices.md; table mappings from constants.
+```
+
+Secrets-in-CFN caveat: prefer `SecretsManagerAccessRoleArn`/`SecretsManagerSecretId` on
+endpoints over inline passwords. Test both endpoints post-deploy in
+`scripts/01-precondition-check.sh` via `aws dms test-connection`.
+
+## proxy-stack.ts (conditional) / monitoring-stack.ts
+
+Proxy: `rds.DatabaseProxy` with `requireTLS: true`, secret-based auth, the app SGs allowed
+in — output the proxy endpoint; Phase 8 points clients at it. Monitoring: the alarm set
+from [../reference/preflight-iam-cost.md](../reference/preflight-iam-cost.md) §4 + a
+dashboard with source-vs-target panels during the migration window, all → one SNS topic.
+
+## scripts/ contract
+
+Each script is idempotent, `set -euo pipefail`, reads identifiers from `cdk` outputs
+(`aws cloudformation describe-stacks --query ...Outputs`), and refuses to run if the
+previous stage's completion marker is absent in `migration-plan.md`. `05-cutover.sh` and
+`06-rollback.sh` are generated from the runbook templates
+([../templates/cutover-runbook.md](../templates/cutover-runbook.md),
+[../templates/rollback-runbook.md](../templates/rollback-runbook.md)) with real values —
+no placeholders left at generation time.
+
+## Post-stabilization changes (the CDK project owns day-2)
+
+- Swap `parameterGroup` migration → production, deploy (reboot-scoped params noted in README).
+- Scale writer down to steady-state instance type.
+- Remove migration-stack entirely (after the rollback window closes).
+- Hand the project to the customer: README documents every constant and the change log.

--- a/db-migration-agent-skill/shared/reference/aws-official-migration-methods.md
+++ b/db-migration-agent-skill/shared/reference/aws-official-migration-methods.md
@@ -1,0 +1,1401 @@
+# AWS Official Database Migration Methods to Amazon RDS & Amazon Aurora
+
+## Comprehensive Reference Guide
+
+**Source**: All information sourced exclusively from official AWS documentation  
+**Last researched**: May 2026  
+**Scope**: Every migration method documented by AWS for moving databases TO Amazon RDS and Amazon Aurora
+
+---
+
+## Table of Contents
+
+1. [AWS Decision Guidance](#aws-decision-guidance)
+2. [Aurora MySQL Migration Methods](#aurora-mysql-migration-methods)
+3. [Aurora PostgreSQL Migration Methods](#aurora-postgresql-migration-methods)
+4. [RDS for MySQL Migration Methods](#rds-for-mysql-migration-methods)
+5. [RDS for PostgreSQL Migration Methods](#rds-for-postgresql-migration-methods)
+6. [RDS for Oracle Migration Methods](#rds-for-oracle-migration-methods)
+7. [RDS for SQL Server Migration Methods](#rds-for-sql-server-migration-methods)
+8. [Cross-Engine & Universal Methods](#cross-engine--universal-methods)
+9. [Quick Reference Matrix](#quick-reference-matrix)
+
+---
+
+## AWS Decision Guidance
+
+### Physical vs. Logical Migration (AWS's Core Framework)
+
+AWS categorizes all migration methods into two fundamental types:
+
+**Physical Migration** (copies database files directly):
+- Faster than logical migration, especially for large databases
+- Database performance does not suffer when a backup is taken
+- Can migrate everything in the source database, including complex database components
+- **Limitations**: Requires `innodb_page_size` set to default (16KB), `innodb_data_file_path` configured with only one data file using default name "ibdata1:12M:autoextend", `innodb_log_files_in_group` must be set to default (2)
+
+**Logical Migration** (applies logical database changes — inserts, updates, deletes):
+- Can migrate subsets of the database (specific tables or parts of tables)
+- Data can be migrated regardless of physical storage structure
+- **Limitations**: Usually slower than physical migration; complex database components can slow or block migration
+
+### AWS Prescriptive Guidance Decision Matrix
+
+AWS provides a decision matrix comparing block-level replication (AWS Application Migration Service) vs. logical data-level replication (native tools or AWS DMS):
+
+| Criteria | AWS Application Migration Service | Database Tools (Native/AWS DMS) |
+|----------|----------------------------------|--------------------------------|
+| Architecture | Physical (block level) | Logical, database engine level |
+| Scale | Large-scale migration | Granular; scale limitations |
+| Speed vs. complexity | Fast exit; reduced complexity | Slower, more complex; requires more planning |
+| Timeline | Supports aggressive timeline | Requires additional effort and time |
+| Migration type | Lift and shift (1:1 only) | Replatforming or modernization (1:many, many:1) |
+| Pre-provisioning | Not required; automatic | Database and infra provisioning required |
+| Downtime | Required, within RTO of minutes | Near-zero downtime possible (expensive) |
+
+**Source**: https://docs.aws.amazon.com/prescriptive-guidance/latest/migration-database-rehost-tools/decision-matrix.html
+
+### AWS's General Recommendations for PostgreSQL
+
+From the official RDS documentation, AWS recommends native PostgreSQL tools when:
+- You have a **homogeneous migration** (same database engine source and target)
+- You are **migrating an entire database**
+- The native tools allow you to migrate with **minimal downtime**
+
+In most **other** cases, AWS states: *"performing a database migration using AWS Database Migration Service (AWS DMS) is the best approach"*
+
+**Source**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Procedural.Importing.html
+
+### AWS's MySQL-to-Aurora Decision Guide
+
+From the DMS Step-by-Step Guide, AWS documents three approaches:
+1. **Native/third-party tools for full load + MySQL replication for ongoing replication** — "Typically the simplest option"
+2. **AWS DMS for full load + ongoing replication** — "provides migration-specific services such as data validation"
+3. **Hybrid**: Native tools for full load + AWS DMS for ongoing replication — "delivers the simplicity of native tools along with additional DMS services"
+
+**Source**: https://docs.aws.amazon.com/dms/latest/sbs/chap-manageddatabases.mysql2rds.html
+
+---
+
+## Aurora MySQL Migration Methods
+
+### Method 1: Aurora Read Replica (from RDS for MySQL)
+
+**Official AWS Name**: Migrating data from an RDS for MySQL DB instance to an Amazon Aurora MySQL DB cluster by using an Aurora read replica
+
+**Migration Type**: Physical
+
+**When AWS Recommends It**: 
+- Migrating from an existing RDS for MySQL DB instance to Aurora MySQL
+- AWS explicitly states: *"For migrating data from a MySQL DB Instance to an Amazon Aurora MySQL DB Cluster, we recommend to use a special type of node called an Aurora Read Replica"*
+- Near-zero downtime requirement
+
+**Prerequisites**:
+- Source must be an RDS for MySQL DB instance
+- Source must run MySQL 5.7 or higher compatible with target Aurora version
+- Source DB instance must have automated backups enabled (backup retention > 0)
+- Binary logging must be enabled on the source (set `binlog_format` to `ROW`)
+- Source cannot be an Amazon Aurora DB instance
+- Source cannot be a read replica itself
+- Source cannot have cross-Region replicas
+
+**Downtime Characteristics**:
+- Near-zero downtime — only seconds of downtime during promotion
+- Applications read from Aurora replica while it catches up
+- When replica lag = 0, promote the replica to standalone cluster
+- Promotion typically takes 1-2 minutes
+
+**What Gets Migrated**:
+- All data and schema objects from the source database
+- InnoDB and MyISAM tables (MyISAM converted to InnoDB)
+
+**What Doesn't Get Migrated**:
+- The source DB instance itself remains unchanged
+- Connection strings need updating after promotion
+
+**Limitations**:
+- Only available for RDS for MySQL → Aurora MySQL
+- Cannot use from external MySQL databases
+- Source cannot already have the maximum number of read replicas (15)
+- Aurora read replica uses same instance class as source or larger
+- Cross-Region Aurora read replicas require publicly accessible instances or VPC peering
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.RDSMySQL.Replica.html
+
+---
+
+### Method 2: RDS for MySQL Snapshot Migration to Aurora
+
+**Official AWS Name**: Migrating an RDS for MySQL snapshot to Aurora
+
+**Migration Type**: Physical
+
+**When AWS Recommends It**:
+- When you have an existing RDS for MySQL DB instance and can tolerate downtime
+- As an alternative to the read replica method when near-zero downtime is not required
+- When you want to create a new Aurora cluster from an existing RDS MySQL state
+
+**Prerequisites**:
+- Source must be an RDS for MySQL DB snapshot (manual or automated)
+- MySQL version must be compatible with Aurora MySQL
+- DB snapshot must be in the same AWS Region as target (or copied to that Region)
+- Sufficient EBS volume space for format conversion during migration
+- MyISAM and compressed tables must not exceed 8 TB individually
+
+**Downtime Characteristics**:
+- Full downtime during migration
+- Duration depends on database size — includes snapshot creation + data format conversion + Aurora cluster creation
+- No writes to source during migration period
+
+**What Gets Migrated**:
+- Complete database state at snapshot time
+- All database objects, data, InnoDB tables
+- MyISAM tables (converted to InnoDB)
+- Compressed tables (expanded)
+
+**What Doesn't Get Migrated**:
+- Any changes after snapshot creation
+- Source DB instance remains running (but data diverges)
+
+**Limitations**:
+- MyISAM tables require additional space during conversion (must not exceed 8 TB)
+- Compressed tables (`ROW_FORMAT=COMPRESSED`) require additional space during expansion
+- The `innodb_page_size` must be default (16KB)
+- One snapshot copy per AWS account per Region at a time
+- Cannot migrate from Aurora MySQL version < 8.0.11, 8.0.13, or 8.0.15 to Aurora MySQL 3.05+
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.RDSMySQL.Import.html
+
+---
+
+### Method 3: Percona XtraBackup + Amazon S3 (from External MySQL)
+
+**Official AWS Name**: Physical migration from MySQL by using Percona XtraBackup and Amazon S3
+
+**Migration Type**: Physical
+
+**When AWS Recommends It**:
+- Migrating from an external (on-premises or EC2) MySQL database to Aurora MySQL
+- *"This option can be considerably faster than migrating data using mysqldump"*
+- Large databases where speed is critical
+- AWS DMS Step-by-Step guide states it's appropriate when: dataset is large, you have admin/system-level access to source, and you migrate 1-to-1 (one source = one target)
+
+**Prerequisites**:
+- Source must be MySQL 5.7 or 8.0
+- Must use Percona XtraBackup version compatible with source MySQL version
+- `innodb_page_size` set to default (16KB)
+- `innodb_data_file_path` = `ibdata1:12M:autoextend` (single default data file)
+- Source must support InnoDB or MyISAM tablespaces
+- An Amazon S3 bucket for backup storage
+- IAM role with S3 access for Aurora
+
+**Downtime Characteristics**:
+- Downtime from the point of final backup until Aurora cluster is available
+- Can use binlog replication to sync Aurora cluster with source after restore (reducing effective downtime)
+- AWS documents a "Synchronizing the Aurora MySQL DB cluster with the MySQL database" step for CDC after restore
+
+**What Gets Migrated**:
+- Complete physical database files
+- All InnoDB tables and data
+- All schema objects
+
+**What Doesn't Get Migrated**:
+- Changes after the backup unless binlog replication is configured post-restore
+- Database users/permissions may need manual recreation
+
+**Limitations**:
+- Cannot migrate into an **existing** Aurora DB cluster — creates a new one
+- Cannot migrate **multiple** source MySQL servers into a single Aurora DB cluster
+- `innodb_data_file_path` cannot have two data files or non-default names
+- `innodb_log_files_in_group` must be default (2)
+- Cannot use if third-party software restricted by OS limitations
+- Source database must use InnoDB or MyISAM tablespaces
+- Cannot migrate to Aurora MySQL 3.05+ from MySQL 8.0.11, 8.0.13, or 8.0.15
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.ExtMySQL.S3.html
+
+---
+
+### Method 4: mysqldump (Logical Migration from External MySQL)
+
+**Official AWS Name**: Logical migration from MySQL to Amazon Aurora MySQL by using mysqldump
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Migrating from an external MySQL database to Aurora MySQL
+- Smaller databases (AWS DMS guide says appropriate when dataset < 10 GB)
+- When network connection between source and target is fast and stable
+- When migration time is not critical
+- When you don't need intermediate schema/data transformations
+- When you need to migrate subsets of data
+
+**Prerequisites**:
+- Source must be MySQL-compatible
+- Network connectivity between source and target (or dump file transfer mechanism)
+- Aurora MySQL DB cluster must already exist
+- Source database must support InnoDB or MyISAM tablespaces
+
+**Downtime Characteristics**:
+- Downtime during dump and restore for basic approach
+- **Reduced downtime approach available**: mysqldump + binary log replication (documented separately)
+  - Initial dump with `--master-data=2` captures binlog position
+  - After restore, configure replication from source to catch up
+  - Cut over when replica lag = 0
+
+**What Gets Migrated**:
+- Database schema and data (logical SQL statements)
+- Can selectively include/exclude objects
+
+**What Doesn't Get Migrated (by default)**:
+- Routines/stored procedures — `mysqldump` **excludes routines by default**; pass `--routines` to include them
+- Events — excluded by default; pass `--events` to include them
+- Triggers — **included by default**; only excluded if you explicitly pass `--skip-triggers`
+- System schemas (mysql, performance_schema, information_schema) are always excluded
+
+**Recommended flags for a complete logical migration**: `mysqldump --single-transaction --routines --triggers --events --set-gtid-purged=OFF --column-statistics=0 ...` — this makes intent explicit and captures everything DMS would skip.
+
+**Limitations**:
+- Slower than physical migration for large databases
+- Complex database components can slow or block migration
+- Performance depends on network bandwidth
+- The `mysqlpump` utility is deprecated as of MySQL 8.0.34
+- If source uses memcached, must remove it before migration
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.ExtMySQL.mysqldump.html
+
+---
+
+### Method 5: LOAD DATA FROM S3 (Text File Import)
+
+**Official AWS Name**: Loading data into an Amazon Aurora MySQL DB cluster from text files in an Amazon S3 bucket
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Loading data from flat files into an existing Aurora MySQL DB cluster
+- When data is available as text/CSV files in S3
+- Supplemental data loading (not necessarily full database migration)
+- In Aurora MySQL version 3 (MySQL 8.0-compatible), version 3.05 and higher
+
+**Prerequisites**:
+- Aurora MySQL DB cluster must already exist
+- Data files in Amazon S3 bucket
+- IAM role associated with the Aurora cluster granting S3 access
+- The `aws_default_s3_role` or role ARN must be configured
+- User must have `LOAD FROM S3` privilege granted via: `GRANT LOAD FROM S3 ON *.* TO 'user'@'domain-or-ip-address'`
+- Target tables must already exist
+
+**Downtime Characteristics**:
+- No downtime for existing database — additive operation
+- Loads data into existing tables
+- Can run while database is online
+
+**What Gets Migrated**:
+- Data from text files (CSV, TSV, or custom-delimited)
+- XML data (via LOAD XML FROM S3)
+
+**What Doesn't Get Migrated**:
+- Schema/table definitions (must pre-create)
+- Stored procedures, triggers, events
+- Users and privileges
+- Indexes must be pre-created (or added after load)
+
+**Limitations**:
+- In Aurora MySQL version 3 (3.01 to 3.04): must grant `AWS_LOAD_S3_ACCESS` role to user
+- In Aurora MySQL version 2: must grant `LOAD FROM S3` privilege
+- Cannot load data from an S3 bucket in a different AWS Region
+- Each `LOAD DATA FROM S3` statement loads from one manifest or one data file
+- The database must have sufficient space for the data being loaded
+- Uses MySQL `LOAD DATA INFILE` syntax with S3 URI
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.LoadFromS3.html
+
+---
+
+### Method 6: Binary Log (Binlog) Replication from External MySQL
+
+**Official AWS Name**: Replication between Aurora and MySQL or between Aurora and another Aurora DB cluster (binary log replication)
+
+**Migration Type**: Logical (continuous replication)
+
+**When AWS Recommends It**:
+- Setting up ongoing replication from external MySQL to Aurora MySQL
+- Near-zero downtime migration from external MySQL
+- Can be combined with other methods (e.g., Percona XtraBackup for initial load, then binlog replication for CDC)
+- Cross-Region replication scenarios
+
+**Prerequisites**:
+- MySQL source version 5.5 or later recommended
+- Binary logging enabled on source
+- Only InnoDB tables (MyISAM must be converted first)
+- Network connectivity between source and Aurora
+- For Aurora MySQL version 2 and 3: supports GTID-based replication
+- GTID-related parameters must be compatible between source and target
+
+**Downtime Characteristics**:
+- Near-zero downtime when combined with initial data load method
+- Continuous replication keeps target in sync
+- Cut over when replica lag = 0
+
+**What Gets Migrated**:
+- All data changes (inserts, updates, deletes) via binary log
+- DDL changes
+
+**What Doesn't Get Migrated**:
+- Initial data (must use another method for baseline)
+- Non-InnoDB tables cannot be replicated
+
+**Limitations**:
+- Not available for Aurora Serverless v1 clusters
+- Only InnoDB tables supported
+- Cross-Region requires publicly accessible instances or VPC peering
+- Cannot use with Aurora Global Database as target
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Replication.MySQL.html
+
+---
+
+### Method 7: AWS DMS (for non-MySQL-compatible sources)
+
+**Official AWS Name**: AWS Database Migration Service (AWS DMS)
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Migrating from a database that is **not MySQL-compatible** to Aurora MySQL
+- Heterogeneous migrations (e.g., Oracle → Aurora MySQL, SQL Server → Aurora MySQL)
+- When you need data validation during migration
+- When you need ongoing replication/CDC from any supported source
+
+**Prerequisites**:
+- DMS replication instance
+- Source and target endpoints configured
+- For heterogeneous migrations: AWS Schema Conversion Tool (SCT) for schema conversion
+- Network connectivity from DMS instance to both source and target
+
+**Downtime Characteristics**:
+- Near-zero downtime possible with CDC
+- Full load causes brief outage on target
+- Full load + CDC: initial load followed by continuous replication
+
+**What Gets Migrated**:
+- Tables and primary keys (auto-created if not existing on target)
+- Data (full load and/or ongoing changes)
+- With SCT: schema objects including indexes, views, triggers
+
+**What Doesn't Get Migrated**:
+- Secondary indexes (not auto-created during full load for performance)
+- Some database-specific objects require SCT
+- Stored procedures, triggers may need manual migration or SCT
+
+**Limitations**:
+- Requires DMS replication instance (additional cost)
+- Performance depends on replication instance size and network
+- Some complex data types may not convert perfectly
+- Check DMS documentation for source/target specific limitations
+
+**Documentation**: https://docs.aws.amazon.com/dms/latest/userguide/Welcome.html
+
+---
+
+### Method 8: Aurora Console Auto-Migration (from EC2 databases)
+
+**Official AWS Name**: Auto migrating EC2 databases to Amazon Aurora using AWS Database Migration Service
+
+**Migration Type**: Logical (uses DMS under the covers)
+
+**When AWS Recommends It**:
+- Migrating MySQL databases running on EC2 instances to Aurora
+- Source databases smaller than 1 TiB
+- Simplifying the DMS setup process
+
+**Prerequisites**:
+- Source must be MySQL on EC2
+- Source and target must be in the same VPC
+- Aurora MySQL DB cluster must already exist
+- MySQL 5.7 or higher on source
+- DMS user with REPLICATION CLIENT and REPLICATION SLAVE privileges (for CDC)
+- SELECT privileges on source tables
+
+**Downtime Characteristics**:
+- Three options:
+  - **Full load**: Causes outage on Aurora database during load
+  - **Full load + CDC**: Causes initial outage, then continuous replication
+  - **CDC only**: No outage — continuous change replication
+
+**What Gets Migrated**:
+- Database tables and data
+- Ongoing changes (with CDC option)
+
+**Limitations**:
+- Cannot migrate to: Aurora Global Database, Aurora Limitless Database, Aurora Serverless v1
+- Cannot migrate from MySQL versions lower than 5.7
+- EC2 instance and target must be in same VPC
+- Maximum recommended source size: 1 TiB
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_DMS_migration.html
+
+---
+
+## Aurora PostgreSQL Migration Methods
+
+### Method 9: RDS for PostgreSQL Snapshot Migration to Aurora PostgreSQL
+
+**Official AWS Name**: Migrating an RDS for PostgreSQL DB instance using a snapshot
+
+**Migration Type**: Physical
+
+**When AWS Recommends It**:
+- Migrating from an existing RDS for PostgreSQL DB instance to Aurora PostgreSQL
+- When downtime is acceptable
+- Simplest path from RDS PostgreSQL to Aurora PostgreSQL
+
+**Prerequisites**:
+- Source must be an RDS for PostgreSQL DB snapshot
+- PostgreSQL version must be supported by Aurora PostgreSQL
+- Strongly recommended: turn off auto minor version upgrades early in migration planning
+- DB snapshot must be in same Region (or copied)
+
+**Downtime Characteristics**:
+- Full downtime during snapshot creation and restoration
+- Duration proportional to database size
+
+**What Gets Migrated**:
+- Complete database state at snapshot time
+- All data and schema objects
+
+**What Doesn't Get Migrated**:
+- Changes after snapshot time
+- Kerberos authentication settings (cannot be enabled during migration)
+
+**Limitations**:
+- Migration may be delayed if RDS for PostgreSQL version isn't yet supported by Aurora PostgreSQL
+- Kerberos authentication can only be enabled on standalone Aurora PostgreSQL cluster (not during migration)
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Migrating.html
+
+---
+
+### Method 10: Aurora Read Replica (from RDS for PostgreSQL)
+
+**Official AWS Name**: Migrating data from an RDS for PostgreSQL DB instance to an Aurora PostgreSQL DB cluster using an Aurora read replica
+
+**Migration Type**: Physical
+
+**When AWS Recommends It**:
+- Near-zero downtime migration from RDS for PostgreSQL to Aurora PostgreSQL
+- When you need continuous sync before cutover
+- AWS recommends this for minimal downtime scenarios
+
+**Prerequisites**:
+- Source must be RDS for PostgreSQL DB instance
+- Source version must be compatible with Aurora PostgreSQL
+- Automated backups enabled on source
+- Source cannot already be at max read replica limit
+- Auto minor version upgrades should be disabled early in planning
+
+**Downtime Characteristics**:
+- Near-zero downtime
+- Only brief interruption during promotion (seconds)
+- Monitor replica lag; promote when lag = 0
+
+**What Gets Migrated**:
+- Complete database via physical replication
+- All data and schema objects
+- Ongoing changes until promotion
+
+**What Doesn't Get Migrated**:
+- Kerberos authentication (must enable post-migration)
+- Application connection strings need updating
+
+**Limitations**:
+- Only available from RDS for PostgreSQL (not external PostgreSQL)
+- Migration may be delayed if version mismatch
+- Same Region only for initial creation
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Migrating.RDSPostgreSQL.Replica.html
+
+---
+
+### Method 11: Import from Amazon S3 into Aurora PostgreSQL
+
+**Official AWS Name**: Importing data from Amazon S3 into Aurora PostgreSQL
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Loading data from S3 files into an existing Aurora PostgreSQL cluster
+- Bulk data loading scenarios
+- When data is available in S3 (e.g., exported from another system)
+
+**Prerequisites**:
+- Aurora PostgreSQL DB cluster must already exist
+- Data files in Amazon S3
+- IAM role with S3 access associated with the cluster
+- `aws_s3` extension installed
+- Target tables must already exist
+
+**Downtime Characteristics**:
+- No downtime — additive operation on existing cluster
+- Can run while database is online
+
+**What Gets Migrated**:
+- Data from files in S3 into existing tables
+
+**What Doesn't Get Migrated**:
+- Schema definitions
+- Database objects (procedures, functions, etc.)
+
+**Limitations**:
+- Target tables must be pre-created
+- Data format must match table structure
+- S3 bucket must be in accessible Region
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Migrating.html (referenced from main migration page)
+
+---
+
+### Method 12: AWS DMS (for non-PostgreSQL sources to Aurora PostgreSQL)
+
+**Official AWS Name**: AWS Database Migration Service (for non-PostgreSQL-compatible sources)
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Migrating from a database that is **not PostgreSQL-compatible** to Aurora PostgreSQL
+- Heterogeneous migrations
+
+**(Same DMS capabilities as described in Method 7 above, targeting Aurora PostgreSQL)**
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Migrating.html
+
+---
+
+## RDS for MySQL Migration Methods
+
+### Method 13: Restore Backup from S3 (Percona XtraBackup)
+
+**Official AWS Name**: Restoring a backup into an Amazon RDS for MySQL DB instance
+
+**Migration Type**: Physical
+
+**When AWS Recommends It**:
+- *"If you are importing or exporting large amounts of data with a MySQL DB instance, it's more reliable and faster to move data in and out of Amazon RDS by using xtrabackup backup files and Amazon S3"*
+- Large-scale external MySQL to RDS MySQL migrations
+
+**Prerequisites**:
+- Source MySQL database (external)
+- Percona XtraBackup for full and incremental backups
+- Amazon S3 bucket to store backup files
+- IAM role granting RDS access to S3
+- Source must be MySQL (not MariaDB — "Amazon RDS only supports importing from Amazon S3 for MySQL")
+
+**Downtime Characteristics**:
+- Downtime from point of backup to when new RDS instance is available
+- Can use binary log replication after restore for CDC (reduced effective downtime)
+
+**What Gets Migrated**:
+- Complete physical database backup
+- All InnoDB data and schema
+
+**What Doesn't Get Migrated**:
+- Changes after backup (unless binlog replication configured)
+- Requires new RDS instance creation
+
+**Limitations**:
+- Creates a **new** RDS instance — cannot restore into existing instance
+- Not supported for MariaDB — only MySQL
+- File size and format constraints apply
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.html
+
+---
+
+### Method 14: mysqldump (Direct Import from External MySQL)
+
+**Official AWS Name**: Importing data from an external MySQL database to an Amazon RDS for MySQL DB instance
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Importing data from existing MariaDB or MySQL database to RDS
+- Piping directly from source to target over network
+- Simpler databases, smaller sizes
+
+**Prerequisites**:
+- mysqldump utility installed (included with MySQL client)
+- Network connectivity from client to both source and target databases
+- User access on both source and target
+- For MariaDB 11.0.1+: must use `mariadb-dump` instead of `mysqldump`
+
+**Downtime Characteristics**:
+- Source remains available during dump (with `--single-transaction`)
+- Target receives data during pipe
+- Full consistency at a single point in time
+
+**What Gets Migrated**:
+- Database schema and table data
+- Specified databases (`--databases` parameter)
+
+**What Doesn't Get Migrated (by default)**:
+- Routines/stored procedures — excluded by default; pass `--routines` to include
+- Events — excluded by default; pass `--events` to include
+- Triggers — **included by default**; use `--skip-triggers` to exclude
+- System schemas (sys, performance_schema, information_schema) are always excluded
+
+**Limitations**:
+- Not suitable for very large databases (slow over network)
+- Requires stable network connection
+- Cannot include routines/triggers directly (must recreate on RDS)
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.SmallExisting.html
+
+---
+
+### Method 15: Reduced Downtime Import (mysqldump + Binary Log Replication)
+
+**Official AWS Name**: Importing data to an Amazon RDS for MySQL database with reduced downtime
+
+**Migration Type**: Logical (with ongoing replication)
+
+**When AWS Recommends It**:
+- When importing from an external MySQL/MariaDB database that supports a **live application**
+- Very large databases
+- When you need to minimize impact on application availability
+- *"Use the following procedure to minimize the impact on availability of applications"*
+
+**Prerequisites**:
+- External MariaDB or MySQL source database
+- Binary logging enabled on source
+- `mysqldump` with `--master-data=2` and `--single-transaction`
+- RDS for MySQL target instance (or Multi-AZ DB cluster)
+- VPN, AWS Direct Connect, or network path between source and target
+- For replication: `mysql.rds_set_external_master` stored procedure
+
+**Downtime Characteristics**:
+- Reduced downtime — only during final cutover
+- Initial dump is consistent snapshot (source remains online)
+- Binary log replication keeps target in sync after initial load
+- Cut over when `Seconds_Behind_Master` = 0
+
+**What Gets Migrated**:
+- Full database via mysqldump (initial load)
+- All subsequent changes via binary log replication
+- Complete data synchronization before cutover
+
+**What Doesn't Get Migrated**:
+- Stored procedures, triggers, events (must recreate manually)
+- System schemas
+
+**Limitations**:
+- Requires configuring external replication (`mysql.rds_set_external_master`)
+- Must stop replication and reset with `mysql.rds_reset_external_master` after cutover
+- Network stability between source and target is critical during replication
+- Replication lag monitoring is essential before cutover
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.NonRDSRepl.html
+
+---
+
+### Method 16: LOAD DATA LOCAL INFILE (Flat File Import)
+
+**Official AWS Name**: Importing data from any source to an Amazon RDS for MySQL DB instance
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Loading data from flat files (CSV, text) into RDS MySQL
+- When data comes from any source (not necessarily MySQL)
+- Bulk loading scenarios
+
+**Prerequisites**:
+- Flat files in CSV or similar format
+- Files split to < 1 GiB each (recommended)
+- Data ordered by primary key (recommended for performance)
+- mysql shell access to RDS instance
+- Target tables must already exist
+
+**Downtime Characteristics**:
+- AWS recommends: "Stop any applications accessing the target DB instance" before load
+- Turning off automated backups reduces load time by ~25%
+- Load time depends on file sizes and network
+
+**What Gets Migrated**:
+- Data from flat files into existing tables
+
+**What Doesn't Get Migrated**:
+- Schema (must pre-create tables)
+- Database objects (procedures, triggers, etc.)
+
+**Limitations**:
+- Files > 1 GiB should be split into multiple files
+- Must invoke mysql shell from same location as files (or use absolute path)
+- Turning off backups erases existing backups and disables point-in-time recovery
+- DB instance restart required when changing backup settings
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.AnySource.html
+
+---
+
+## RDS for PostgreSQL Migration Methods
+
+### Method 17: pg_dump / pg_restore (from EC2 or External PostgreSQL)
+
+**Official AWS Name**: Importing a PostgreSQL database from an Amazon EC2 instance
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Homogeneous PostgreSQL migration
+- Migrating entire database
+- When native tools provide minimal downtime
+
+**Prerequisites**:
+- `pg_dump` utility available
+- Network connectivity to target RDS instance
+- Target RDS instance created with backup retention = 0 and Multi-AZ disabled (for faster import)
+- Cannot use `pg_dumpall` (requires super_user not available in RDS)
+
+**Downtime Characteristics**:
+- Source available during dump (consistent snapshot)
+- Duration proportional to database size
+- Recommended optimizations: disable backups, disable Multi-AZ during import
+
+**What Gets Migrated**:
+- Database schema (tables, indexes, foreign keys)
+- All table data
+- Can restore to same-name or different-name database
+
+**What Doesn't Get Migrated**:
+- Data requiring `pg_dumpall` (global objects like roles across databases)
+- Changes after dump unless replication configured
+
+**Recommended Parameters During Import** (from AWS docs):
+| Parameter | Recommended Value | Purpose |
+|-----------|------------------|---------|
+| `maintenance_work_mem` | 512MB - 4GB | Speed up CREATE INDEX |
+| `max_wal_size` | 256 (v9.6) / 4096 (v10+) | Less frequent checkpoints |
+| `checkpoint_timeout` | 1800 | Less frequent WAL rotation |
+| `synchronous_commit` | Off | Speed up writes |
+| `wal_buffers` | 8192 | WAL generation speed |
+| `autovacuum` | 0 | Don't consume resources during load |
+
+**Limitations**:
+- `pg_dumpall` not usable (no super_user in RDS)
+- Must revert parameter changes after import
+- Must re-enable backups and Multi-AZ after import
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Procedural.Importing.EC2.html
+
+---
+
+### Method 18: \copy Command (psql Meta-Command)
+
+**Official AWS Name**: Using the \copy command to import data to a table on a PostgreSQL DB instance
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Importing CSV data into existing tables
+- Client-side data loading
+- When data is available as CSV files on local workstation
+
+**Prerequisites**:
+- `psql` client connected to target RDS PostgreSQL instance
+- CSV files on local workstation
+- Target tables must already exist with correct structure
+
+**Downtime Characteristics**:
+- No downtime — additive operation
+- Loads data while database is online
+
+**What Gets Migrated**:
+- Data from CSV files into specified tables
+
+**What Doesn't Get Migrated**:
+- Schema definitions
+- Any database objects
+
+**Limitations**:
+- Client-side operation (data goes through client machine)
+- Limited by client network bandwidth
+- Tables must be pre-created
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Procedural.Importing.Copy.html
+
+---
+
+### Method 19: Import from Amazon S3 into RDS for PostgreSQL
+
+**Official AWS Name**: Importing data from Amazon S3 into an RDS for PostgreSQL DB instance
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Bulk loading data from S3 into RDS PostgreSQL
+- When data is already in S3 (exported from another system)
+- Server-side import (faster than client-side \copy)
+
+**Prerequisites**:
+- `aws_s3` extension installed on RDS PostgreSQL
+- IAM role with S3 access associated with the DB instance
+- Data files in S3 bucket
+- Target tables must exist
+
+**Downtime Characteristics**:
+- No downtime — additive operation
+- Server-side operation (bypasses client)
+
+**What Gets Migrated**:
+- Data from S3 files into existing tables
+
+**What Doesn't Get Migrated**:
+- Schema definitions
+- Database objects
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Procedural.Importing.html (subsection)
+
+---
+
+### Method 20: PostgreSQL Transportable Databases (pg_transport)
+
+**Official AWS Name**: Transporting PostgreSQL databases between DB instances
+
+**Migration Type**: Physical
+
+**When AWS Recommends It**:
+- *"A very fast way to migrate large databases between different DB instances"*
+- Moving databases between RDS for PostgreSQL instances
+- When speed is critical for large databases
+
+**Prerequisites**:
+- Both source and destination must be RDS for PostgreSQL instances
+- Both must run the **same major version** of PostgreSQL
+- `pg_transport` extension installed on both instances
+- Source can only have `pg_transport` extension installed (no other extensions)
+- All source database objects must be in default `pg_default` tablespace
+- Available in RDS for PostgreSQL 11.5+, and 10.10+
+
+**Downtime Characteristics**:
+- Source database is put into **read-only mode** during transport
+- Source database sessions are ended when transport begins
+- Source database allows read-only queries during transport
+- Write-enabled queries blocked on source during transport
+- Destination not available for point-in-time recovery during transport (backup taken after)
+
+**What Gets Migrated**:
+- Complete database via physical transport (file-level copy)
+- Much faster than dump and load
+
+**What Doesn't Get Migrated**:
+- Access privileges and ownership (not carried over)
+- All objects created and owned by destination user
+- `reg` data types (depend on OIDs that change during transport)
+
+**Limitations**:
+- **RDS for PostgreSQL instances only** — cannot use with on-premises or EC2 databases
+- Cannot use on read replicas or parent instances of read replicas
+- Cannot use `reg` data types in transported tables
+- All objects must be in `pg_default` tablespace
+- Both instances must be same PostgreSQL major version
+- Source can only have `pg_transport` extension
+- Up to 32 concurrent transports per instance
+- If transport fails, source may remain in read-only mode (requires manual fix)
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.TransportableDB.html
+
+---
+
+## RDS for Oracle Migration Methods
+
+### Method 21: Oracle SQL Developer
+
+**Official AWS Name**: Importing using Oracle SQL Developer
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Small databases (~20 MB)
+- Simple migrations
+- Using the Database Copy command
+
+**Prerequisites**:
+- Oracle SQL Developer installed (free from Oracle)
+- Network connectivity to both source and target
+- Credentials for both databases
+
+**Downtime Characteristics**:
+- Source remains available during copy
+- Duration depends on database size
+
+**What Gets Migrated**:
+- Data and schema (via Database Copy command)
+- Can also migrate from MySQL/SQL Server to Oracle
+
+**Limitations**:
+- Best for **small databases** only
+- GUI-based tool
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.SQLDeveloper.html
+
+---
+
+### Method 22: Oracle Data Pump
+
+**Official AWS Name**: Importing using Oracle Data Pump
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- *"The recommended way to move large amounts of data from an Oracle database"*
+- Complex databases
+- Databases of several hundred megabytes to several terabytes
+- Long-term replacement for Oracle Export/Import utilities
+
+**Two Sub-Methods**:
+1. **Oracle Data Pump with Amazon S3**: Export dump file, upload to S3, import via S3 integration
+2. **Oracle Data Pump with Database Link**: Direct import over database link from source to target
+
+**Prerequisites**:
+- Oracle Data Pump utilities (expdp/impdp)
+- For S3 method: S3 bucket, IAM role, Amazon S3 integration enabled on RDS instance
+- For DB Link method: Network connectivity and database link between source and target
+- Sufficient storage for dump files
+
+**Downtime Characteristics**:
+- Source remains available during export
+- Import duration depends on data volume
+- No built-in CDC — point-in-time migration
+
+**What Gets Migrated**:
+- Full schemas or specific objects
+- Data, indexes, constraints
+- PL/SQL objects (when compatible)
+
+**Limitations**:
+- Dump file size constraints based on instance storage
+- Not all Oracle features supported identically in RDS
+- Database link requires network path between source and RDS
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.DataPump.html
+
+---
+
+### Method 23: Oracle Transportable Tablespaces
+
+**Official AWS Name**: Migrating using Oracle transportable tablespaces
+
+**Migration Type**: Physical
+
+**When AWS Recommends It**:
+- Moving tablespaces from on-premises Oracle to RDS for Oracle
+- Large datasets where Data Pump would be too slow
+- Can use Amazon S3 or Amazon EFS for data file transfer
+
+**Prerequisites**:
+- Amazon S3 integration or Amazon EFS integration configured
+- Compatible Oracle versions
+- Tablespace in read-only mode for transport
+
+**What Gets Migrated**:
+- Complete tablespace data files
+- Metadata via Data Pump
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.html (references transportable tablespaces)
+
+---
+
+### Method 24: Oracle SQL*Loader
+
+**Official AWS Name**: Importing using Oracle SQL*Loader
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- *"Large databases that contain a limited number of objects"*
+- Bulk loading data from flat files
+- When schema is relatively simple
+
+**Prerequisites**:
+- Oracle SQL*Loader utility (via Oracle Instant Client)
+- Control file defining data format
+- Data exported as flat files from source
+- Target tables must exist on RDS Oracle
+
+**Downtime Characteristics**:
+- No downtime on target — additive operation
+- Source export may require brief lock
+
+**What Gets Migrated**:
+- Data from flat files into existing tables
+
+**What Doesn't Get Migrated**:
+- Schema (must pre-create)
+- PL/SQL objects
+- Indexes (must pre/post-create)
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.SQLLoader.html
+
+---
+
+### Method 25: Oracle Materialized Views
+
+**Official AWS Name**: Migrating with Oracle materialized views
+
+**Migration Type**: Logical (with ongoing replication)
+
+**When AWS Recommends It**:
+- *"To migrate large datasets efficiently"*
+- When you need ongoing synchronization before cutover
+- When you want to switch over to Amazon RDS later
+
+**Prerequisites**:
+- Database link from RDS Oracle target to source database
+- Access rules on source allowing RDS target to connect via SQL*Net
+- User account on both source and target with same password
+- Materialized view log on source tables
+- `CREATE SESSION`, `SELECT ANY TABLE`, `SELECT ANY DICTIONARY` privileges
+
+**Downtime Characteristics**:
+- Near-zero downtime
+- Materialized views keep target synchronized
+- Cut over by: refreshing final time → dropping materialized view with `PRESERVE TABLE`
+- The retained table has same name as dropped materialized view
+
+**What Gets Migrated**:
+- Table data via materialized view replication
+- Ongoing changes until cutover
+
+**What Doesn't Get Migrated**:
+- Schema objects other than tables (must create separately)
+- PL/SQL packages, procedures
+
+**Limitations**:
+- Requires direct network access from RDS to source
+- Source must have materialized view logs created
+- Only works for Oracle-to-Oracle migration
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.Materialized.html
+
+---
+
+### Method 26: Oracle Export/Import (Legacy)
+
+**Official AWS Name**: Importing using Oracle Export/Import
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Legacy method; Oracle Data Pump is the recommended replacement
+- May be needed for very old Oracle versions
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.html
+
+---
+
+## RDS for SQL Server Migration Methods
+
+### Method 27: Native Backup and Restore (.bak files via S3)
+
+**Official AWS Name**: Importing and exporting SQL Server databases using native backup and restore
+
+**Migration Type**: Physical
+
+**When AWS Recommends It**:
+- *"If your database can be offline while the backup file is created, copied, and restored, we recommend that you use native backup and restore to migrate it to RDS"*
+- *"Usually the fastest way to back up and restore databases"*
+- When database can tolerate downtime during migration
+
+**Prerequisites**:
+- Full backup file (.bak) from source SQL Server
+- Amazon S3 bucket to store backup files
+- IAM role with S3 access for RDS
+- Option group with `SQLSERVER_BACKUP_RESTORE` option configured
+- Symmetric encryption AWS KMS key (if encrypting)
+
+**Downtime Characteristics**:
+- Database offline from backup start to restore completion
+- AWS states this is the fastest method when offline is acceptable
+
+**What Gets Migrated**:
+- Complete database including: data, schemas, stored procedures, triggers, and other database code
+- Single databases (not entire instance)
+- TDE-encrypted databases supported
+
+**What Doesn't Get Migrated**:
+- Instance-level objects
+- SQL Server Agent jobs
+- Linked servers
+- Login information (at instance level)
+
+**Limitations**:
+- Cannot backup/restore from S3 in different AWS Region than the RDS instance
+- Cannot restore a database with same name as existing database
+- Maximum 5 TB per file; larger databases use multifile backup
+- Maximum 10 backup files simultaneously
+- Cannot do native log backups from RDS SQL Server
+- On Multi-AZ: can only natively restore databases backed up in **full recovery model**
+- Up to 2 backup/restore tasks simultaneously
+- Cannot restore during maintenance window
+- FILESTREAM file groups not supported
+- Differential backups cannot have snapshots between full backup and differential
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Procedural.Importing.html
+
+---
+
+### Method 28: SQL Server Import via Snapshot (Generate and Publish Scripts / Import Wizard)
+
+**Official AWS Name**: Importing data into RDS for SQL Server by using a snapshot
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Alternative to native backup when database cannot be offline
+- Using SQL Server tools for migration
+
+**Sub-Methods**:
+- **Generate and Publish Scripts Wizard**: Creates SQL scripts for schema + data
+- **Import and Export Wizard**: SSIS-based data movement
+- **Bulk Copy (BCP)**: Command-line bulk data transfer
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Procedural.Importing.html
+
+---
+
+### Method 29: BCP Utility (from Linux)
+
+**Official AWS Name**: Using BCP utility from Linux to import and export data
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Bulk importing/exporting data to/from RDS for SQL Server from Linux environments
+- When native backup isn't suitable
+
+**Prerequisites**:
+- SQL Server command-line tools installed on Linux
+- `mssql-tools` package
+- Network connectivity to RDS SQL Server instance
+
+**Documentation**: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Procedural.Importing.html
+
+---
+
+## Cross-Engine & Universal Methods
+
+### Method 30: AWS Database Migration Service (AWS DMS) — Universal
+
+**Official AWS Name**: AWS Database Migration Service
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- Heterogeneous migrations (different source and target engines)
+- When near-zero downtime is required
+- When you need **data validation** during migration
+- When you need ongoing replication
+- *"In most other cases, performing a database migration using AWS DMS is the best approach"*
+- *"If your on-premises database can't be offline, we recommend that you use AWS Database Migration Service"*
+
+**Prerequisites**:
+- DMS replication instance in same VPC or with connectivity to target
+- Source and target endpoints
+- For heterogeneous: AWS Schema Conversion Tool (SCT) or DMS Schema Conversion
+- Network connectivity (VPN, Direct Connect, or public internet)
+
+**Downtime Characteristics**:
+- **Full load only**: Downtime during load
+- **Full load + CDC**: Brief downtime during initial load, then continuous replication
+- **CDC only**: No downtime (requires pre-loaded baseline)
+- Near-zero downtime achievable with CDC
+
+**What Gets Migrated**:
+- Tables and associated primary keys (auto-created)
+- Data (all rows or filtered subsets)
+- Ongoing changes (with CDC)
+- With SCT: schema objects, indexes, views, triggers, stored procedures
+
+**What Doesn't Get Migrated** (without SCT):
+- Secondary indexes (not auto-created during full load)
+- Triggers, views, stored procedures (require SCT or manual migration)
+- Some database-specific objects
+
+**Supported Sources → RDS/Aurora Targets**:
+- Oracle → Any RDS/Aurora engine
+- SQL Server → Any RDS/Aurora engine
+- MySQL → RDS MySQL, Aurora MySQL
+- PostgreSQL → RDS PostgreSQL, Aurora PostgreSQL
+- MariaDB → RDS MariaDB, Aurora MySQL
+- MongoDB → (with limitations)
+- IBM Db2 → Any RDS engine
+- SAP ASE → Any RDS engine
+- And many more (see DMS documentation)
+
+**Limitations**:
+- Requires separate DMS replication instance (cost and management)
+- LOB columns may require special handling
+- Some data type conversions may lose fidelity
+- Performance depends on replication instance size, network, and source load
+- CDC requires source database to have logging enabled (binlog, WAL, redo logs, etc.)
+
+**Documentation**: https://docs.aws.amazon.com/dms/latest/userguide/Welcome.html
+
+---
+
+### Method 31: AWS Schema Conversion Tool (AWS SCT)
+
+**Official AWS Name**: AWS Schema Conversion Tool
+
+**Migration Type**: Schema conversion (companion to DMS)
+
+**When AWS Recommends It**:
+- Heterogeneous migrations where schema objects need conversion
+- Used alongside DMS for complete migration
+- Converting stored procedures, functions, views between engines
+
+**What It Does**:
+- Converts schema objects from source engine format to target engine format
+- Identifies conversion issues and provides action items
+- Generates converted DDL for target engine
+
+**Documentation**: Referenced from DMS documentation and Aurora migration guides
+
+---
+
+### Method 32: AWS Application Migration Service (MGN) — Block-Level
+
+**Official AWS Name**: AWS Application Migration Service
+
+**Migration Type**: Physical (block-level replication)
+
+**When AWS Recommends It** (from Prescriptive Guidance):
+- Large-scale lift-and-shift migrations
+- Aggressive timelines
+- When simplicity is paramount (reduced complexity vs. database tools)
+- 1-to-1 server migrations only
+
+**Downtime Characteristics**:
+- Downtime required during cutover
+- RTO of minutes
+
+**Limitations**:
+- Doesn't support clustered systems (NAS, NFS, CIFS/SMB)
+- Only supports x86 platforms (Windows or Linux)
+- Only supports block-level storage directly attached to migrated system
+- Cannot replatform or modernize (lift and shift only)
+- After migration, database runs on EC2 (not RDS/Aurora) — additional migration to managed service still needed
+
+**Documentation**: https://docs.aws.amazon.com/prescriptive-guidance/latest/migration-database-rehost-tools/decision-matrix.html
+
+---
+
+### Method 33: mydumper/myloader (Third-Party, AWS-Documented)
+
+**Official AWS Name**: Referenced in AWS DMS Step-by-Step Guide as "mydumper"
+
+**Migration Type**: Logical
+
+**When AWS Recommends It**:
+- When migration time is critical
+- When Percona XtraBackup cannot be used
+- Multithreaded schema and data migration
+- Better performance than mysqldump for large datasets
+
+**Key Advantages Over mysqldump** (per AWS docs):
+- Parallel backups
+- Consistent reads
+- Built-in compression
+- Each table in separate file
+
+**When NOT to use** (per AWS):
+- When migrating from RDS for MySQL or MySQL 5.5/5.6 (XtraBackup may be better)
+- When OS limitations prevent third-party software
+- When intermediate dump files need flat-file format (mydumper uses SQL format)
+
+**Documentation**: https://docs.aws.amazon.com/dms/latest/sbs/chap-manageddatabases.mysql2rds.fullload.html
+
+---
+
+## Quick Reference Matrix
+
+### Migration Methods by Source → Target
+
+| Source | Target | Methods Available |
+|--------|--------|-------------------|
+| RDS MySQL | Aurora MySQL | Read Replica (M1), Snapshot (M2), Binlog Replication (M6), DMS (M7) |
+| External MySQL | Aurora MySQL | Percona XtraBackup+S3 (M3), mysqldump (M4), LOAD DATA FROM S3 (M5), Binlog Replication (M6), DMS (M7), mydumper (M33) |
+| EC2 MySQL | Aurora MySQL | Console Auto-Migration (M8), Percona XtraBackup+S3 (M3), mysqldump (M4), DMS (M7) |
+| RDS PostgreSQL | Aurora PostgreSQL | Snapshot (M9), Read Replica (M10), DMS (M12) |
+| External PostgreSQL | Aurora PostgreSQL | S3 Import (M11), DMS (M12), pg_dump/pg_restore |
+| External MySQL | RDS MySQL | Percona XtraBackup+S3 (M13), mysqldump (M14), Reduced Downtime (M15), LOAD DATA (M16), DMS (M30) |
+| External PostgreSQL | RDS PostgreSQL | pg_dump/pg_restore (M17), \copy (M18), S3 Import (M19), DMS (M30) |
+| RDS PostgreSQL | RDS PostgreSQL | Transportable Databases (M20) |
+| External Oracle | RDS Oracle | SQL Developer (M21), Data Pump (M22), Transportable Tablespaces (M23), SQL*Loader (M24), Materialized Views (M25), DMS (M30) |
+| External SQL Server | RDS SQL Server | Native Backup/Restore (M27), BCP (M29), DMS (M30) |
+| Any non-compatible engine | Any RDS/Aurora | DMS (M30) + SCT (M31) |
+
+### By Downtime Requirement
+
+| Downtime Tolerance | Recommended Methods |
+|-------------------|-------------------|
+| **Near-zero downtime** | Read Replica (M1, M10), Binlog Replication (M6, M15), Materialized Views (M25), DMS with CDC (M30) |
+| **Minutes of downtime** | Read Replica promotion, MGN block-level cutover |
+| **Moderate downtime** | Snapshot migration (M2, M9), Percona XtraBackup+S3 (M3, M13), Native Backup/Restore SQL Server (M27) |
+| **Extended downtime OK** | mysqldump (M4, M14), pg_dump (M17), Data Pump (M22), SQL*Loader (M24) |
+
+### By Database Size (AWS Recommendations)
+
+| Database Size | Recommended Methods |
+|--------------|-------------------|
+| **< 10 GB** | mysqldump (M4, M14), pg_dump (M17), SQL Developer (M21), \copy (M18) |
+| **10 GB - 1 TB** | Percona XtraBackup+S3 (M3, M13), Read Replica (M1, M10), DMS (M30), mydumper (M33), Console Auto-Migration (M8) |
+| **> 1 TB** | Percona XtraBackup+S3 (M3, M13), Read Replica (M1, M10), Transportable Tablespaces (M23), Transportable Databases (M20), Native Backup/Restore (M27) |
+
+### By Migration Type
+
+| Type | Methods |
+|------|---------|
+| **Physical** | Read Replica (M1, M10), Snapshot (M2, M9), Percona XtraBackup+S3 (M3, M13), Transportable Databases (M20), Transportable Tablespaces (M23), Native Backup/Restore SQL Server (M27), MGN (M32) |
+| **Logical** | mysqldump (M4, M14), LOAD DATA FROM S3 (M5), Binlog Replication (M6), DMS (M7, M30), pg_dump (M17), \copy (M18), Data Pump (M22), SQL*Loader (M24), Materialized Views (M25), BCP (M29), mydumper (M33) |
+
+---
+
+## Key Documentation Links (Complete Index)
+
+| Topic | URL |
+|-------|-----|
+| Aurora MySQL Migration Overview | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.html |
+| Aurora PostgreSQL Migration Overview | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Migrating.html |
+| Aurora MySQL Read Replica Migration | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.RDSMySQL.Replica.html |
+| Aurora MySQL Snapshot Migration | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.RDSMySQL.Import.html |
+| Percona XtraBackup + S3 (Aurora) | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.ExtMySQL.S3.html |
+| mysqldump to Aurora MySQL | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.ExtMySQL.mysqldump.html |
+| LOAD DATA FROM S3 (Aurora MySQL) | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.LoadFromS3.html |
+| Aurora MySQL Binlog Replication | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Replication.MySQL.html |
+| Aurora PostgreSQL Read Replica Migration | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Migrating.RDSPostgreSQL.Replica.html |
+| Aurora Console Auto-Migration (EC2) | https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_DMS_migration.html |
+| RDS MySQL Backup Restore from S3 | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.html |
+| RDS MySQL mysqldump Import | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.SmallExisting.html |
+| RDS MySQL Reduced Downtime Import | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.NonRDSRepl.html |
+| RDS MySQL Flat File Import | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.AnySource.html |
+| RDS PostgreSQL Import Overview | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Procedural.Importing.html |
+| RDS PostgreSQL pg_dump Import | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Procedural.Importing.EC2.html |
+| RDS PostgreSQL \copy Import | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Procedural.Importing.Copy.html |
+| PostgreSQL Transportable Databases | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.TransportableDB.html |
+| RDS Oracle Import Overview | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.html |
+| Oracle SQL Developer | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.SQLDeveloper.html |
+| Oracle Data Pump | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.DataPump.html |
+| Oracle SQL*Loader | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.SQLLoader.html |
+| Oracle Materialized Views | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Procedural.Importing.Materialized.html |
+| SQL Server Native Backup/Restore | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Procedural.Importing.html |
+| RDS Read Replicas | https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html |
+| AWS DMS Overview | https://docs.aws.amazon.com/dms/latest/userguide/Welcome.html |
+| DMS MySQL Migration Guide | https://docs.aws.amazon.com/dms/latest/sbs/chap-manageddatabases.mysql2rds.html |
+| DMS MySQL Full Load Options | https://docs.aws.amazon.com/dms/latest/sbs/chap-manageddatabases.mysql2rds.fullload.html |
+| AWS Prescriptive Guidance Decision Matrix | https://docs.aws.amazon.com/prescriptive-guidance/latest/migration-database-rehost-tools/decision-matrix.html |
+
+---
+
+*This document covers 33 distinct migration methods/tools documented by AWS across all RDS and Aurora engine types. All information sourced directly from official AWS documentation.*

--- a/db-migration-agent-skill/shared/reference/customer-test-integration.md
+++ b/db-migration-agent-skill/shared/reference/customer-test-integration.md
@@ -1,0 +1,37 @@
+# Integrating the Customer's Own Tests (Discovery Q18 → Rehearsal/Soak Gates)
+
+> How to actually *run* the customer's existing tests against the target. The tests live
+> in the customer's systems (CI, QA tools, repos) — **never ask them to paste test code
+> into chat.** The working principle: **their tests, their runner, your endpoint.** The
+> skill supplies a target endpoint + credentials; the customer's existing machinery
+> executes; the pass/fail evidence flows back into the soak report.
+
+## The four integration patterns (pick per what the customer has)
+
+| Customer has | Integration | Who runs it | Evidence back |
+|--------------|-------------|-------------|---------------|
+| **CI pipeline** (Jenkins/GitHub Actions/GitLab/CodePipeline) with a test stage that takes a DB endpoint/profile | Ask for a **parameterized run**: they trigger the existing job with the DB host/secret overridden to the target (most test stages already read `DB_HOST`/JDBC URL from env or a profile). If the runner is outside the VPC, provide the private endpoint via their existing runner network path — never a public endpoint | Customer's CI | The CI run URL + pass/fail counts, pasted or screenshotted into the soak report row |
+| **A test/staging environment** of the application | Repoint the *staging app's* DB config at the target (same client-repoint mechanics as Phase 7.5, applied to staging) and let QA run their normal UAT pass | Customer QA | QA sign-off note recorded in `authorizations.md`; defects triaged migration-related vs pre-existing |
+| **Runnable scripts/suites in a repo** (pytest/JUnit/k6/JMeter/SQL scripts) but no convenient runner in-VPC | Stand up a **throwaway test-runner host inside the migration VPC** (small EC2/ECS task, SSM-only, torn down with the engagement); customer grants read access to the repo or supplies the artifact; the agent executes verbatim — **never edit their tests**; a failing test is a finding, not something to fix | Agent, on the runner | Full run log attached to the plan; summary row in the soak report |
+| **Nothing formal** (very common) | Do NOT fabricate a "suite" and call it theirs. Offer two honest options: (a) the skill's built-in minimum — per-major-table CRUD round-trip + top-N query replay against the baseline (validation-patterns.md); (b) a **10-minute interview**: "name the 3–5 business actions that must work" (place order, refund, monthly report...) → script exactly those as named smoke checks the customer reviews and approves as *their* acceptance list | Agent | The approved checklist + results; Tier 3 without a real suite = recorded waiver |
+
+## Rules
+
+1. **Read-only vs writing tests.** Ask which the suite is. Write-tests are fine against a
+   rehearsal clone or a soaking target **before** it becomes authoritative, but their
+   writes must be excluded from row-count/checksum comparisons (tag a test window, or
+   diff-check only outside it). Never run customer write-tests against the target after
+   cutover authorization without noting the window.
+2. **Their tests are immutable.** If a test fails on the target, the finding goes in the
+   plan (migration defect? pre-existing failure? environment config?) — the agent never
+   "fixes" the test to make it pass. Ask the customer to run the same suite against the
+   *source* once, early, to establish which failures are pre-existing.
+3. **Where results live**: each suite execution = a row in the daily soak report
+   (`{suite: n pass / n fail}`) + the run log/URL referenced in `migration-plan.md`
+   Phase 7.7. Tier 3: the final pre-cutover run is a named sign-off row in
+   `authorizations.md`.
+4. **Load tests** (k6/JMeter/Gatling/nGrinder): run against the target during the soak at
+   production-like concurrency — this is the Tier 3 performance-validation input. Compare
+   p95/p99 against the source baseline from Phase 2, not against absolute thresholds.
+5. **Secrets**: the runner gets the target credentials the same way everything else does
+   — a scoped Secrets Manager secret, never pasted into a pipeline variable in chat.

--- a/db-migration-agent-skill/shared/reference/cutover-procedures.md
+++ b/db-migration-agent-skill/shared/reference/cutover-procedures.md
@@ -1,0 +1,519 @@
+# Zero-Downtime Cutover Procedures
+
+## Overview
+
+The cutover is the highest-risk phase of the migration. This document provides step-by-step procedures for three cutover methods, ranked by recommendation.
+
+---
+
+## Pre-cutover: Discover DB Clients (MANDATORY — do this first)
+
+Before changing anything, enumerate EVERY client that connects to the source DB. Migrating the DB
+without repointing all clients = **split data** (a missed client keeps writing the old DB) or
+**outage** (a missed client can't reach the new one). This is the single highest operational risk.
+
+### Step 1 — Trace via Security Group
+
+The source DB's security-group ingress reveals who is allowed to connect:
+```bash
+aws ec2 describe-security-groups --group-ids <db-sg> \
+  --query "SecurityGroups[].IpPermissions[?ToPort==\`3306\`].[UserIdGroupPairs[].GroupId, IpRanges[].CidrIp]"
+```
+For each allowed source SG, list the resources attached to it (EC2 / ECS / Lambda-in-VPC via ENIs):
+```bash
+aws ec2 describe-instances --filters Name=instance.group-id,Values=<client-sg> \
+  --query "Reservations[].Instances[].[InstanceId,PrivateIpAddress,Tags[?Key=='Name'].Value|[0]]"
+aws ec2 describe-network-interfaces --filters Name=group-id,Values=<client-sg> \
+  --query "NetworkInterfaces[].[PrivateIpAddress,Description,InterfaceType]"
+```
+
+### Step 2 — Inspect each client's connection config (config can live in MANY places)
+
+Check all of these in **override order** — a later source overrides an earlier one:
+
+| Priority (highest wins) — Location | How to check |
+|------------------------------------|--------------|
+| 1. Process args | `ps -eo args \| grep -iE "jdbc:\|DB_HOST\|datasource\|--spring"` |
+| 2. Env files / vars | `cat <EnvironmentFile>`; `systemctl show <svc> -p Environment` |
+| 3. systemd units | `grep -rn "jdbc:\|DB_HOST\|datasource" /etc/systemd/system/` |
+| 4. App config | `application*.properties`/`.yml`, `.env`, `config.js/json` |
+| 5. Secrets Manager | `aws secretsmanager get-secret-value --secret-id <id> --query SecretString` — **does it even contain `host`?** |
+| 6. Hardcoded IPs | `grep -rn "<source-private-ip>" /etc /opt /home /srv 2>/dev/null` |
+
+**Containerized clients** (the ENIs found in Step 1 often belong to these — same
+override-order logic, different locations):
+
+| Runtime | Where the DB host hides | How to check / repoint |
+|---------|-------------------------|------------------------|
+| **ECS** | Task definition `environment`/`secrets`, or the image itself | `aws ecs describe-task-definition --task-definition <fam> --query 'taskDefinition.containerDefinitions[].{env:environment,sec:secrets}'` → register a new revision + `aws ecs update-service --force-new-deployment` |
+| **EKS / Kubernetes** | ConfigMap, Secret, Deployment env, Helm values | `kubectl get deploy <d> -o jsonpath='{..env}'`; `kubectl get configmap,secret -o yaml \| grep -i <source-ip-or-host>` → edit source-of-truth (GitOps repo/Helm values, not live objects) + `kubectl rollout restart deploy/<d>` |
+| **Lambda (in-VPC)** | Function env vars or the secret it reads | `aws lambda get-function-configuration --function-name <f> --query 'Environment.Variables'` → `update-function-configuration` (next invocation picks it up) |
+| **CI/batch runners** | Job env (Jenkins credentials, GitHub Actions secrets, Airflow connections) | Search the scheduler's connection store for the source host; these are the clients everyone forgets — they only connect at run time, so the processlist cross-check (Step 3) misses them outside their schedule. |
+
+**On-premises clients** (no security group to trace): work Step 3 first — the processlist
+shows connected on-prem IPs — then netstat on the DB host (`ss -tnp state established
+'( sport = :3306 )'`) over a full business cycle (include the batch window: nightly/weekly
+jobs are invisible in a 10-minute sample). Ask the network team for firewall/NAT logs to
+the DB port as the authoritative list.
+
+**The DB host itself is a client** — always inspect it. Local cron jobs, backup scripts,
+and maintenance tasks connect via localhost, so they never appear in SG rules and only
+appear in the processlist during their schedule window. They silently die when the host is
+decommissioned (losing, e.g., the only backup) or keep dumping a stale DB. Check
+explicitly — customers forget these exist until asked:
+```bash
+ls /etc/cron.d/ /etc/cron.daily/ /etc/cron.weekly/; crontab -l; \
+  for u in root mysql postgres; do crontab -l -u $u 2>/dev/null; done
+grep -rl "mysql\|psql\|mysqldump\|pg_dump" /etc/cron* /var/spool/cron 2>/dev/null
+systemctl list-timers --no-pager | head -20
+```
+Each hit gets an inventory row and a disposition: retire (RDS automated backups replace a
+local dump script), move to EventBridge Scheduler/Lambda, or re-home to another host
+pointed at the new endpoint.
+
+- **Every host-side change must land in the customer's source of truth, or it WILL be
+  reverted by their own automation.** Live hosts are usually deploy artifacts: the systemd
+  unit came from Ansible/Chef/a CI pipeline, the task definition from IaC, the ConfigMap
+  from a GitOps repo. A change made only on the box survives until the next deploy — then
+  the pipeline re-applies the old config and the app silently reconnects to the retired
+  source (or dies with it). Rules: (1) at discovery, ask **where each client's config is
+  deployed FROM** (repo/pipeline/IaC) — record it in the client inventory; (2) the cutover
+  plan for that client is a **change to that repo deployed through their pipeline**, not
+  (only) an SSH edit. Default mechanics: the agent produces an **exact change specification**
+  (file, key, old value → new value, e.g. the one-line endpoint diff) and the **customer's
+  team commits and merges it themselves** — the agent does not need or ask for repo access,
+  and verifies the *deployed result* on the host afterwards. Only if the customer
+  explicitly grants repo access (recorded in authorizations.md) may the agent raise a PR
+  directly — and then PRs only, never direct pushes, with the customer merging; (3) a direct on-host edit is acceptable ONLY as the cutover-window
+  mechanism itself, and then ONLY with a same-day follow-up task (tracked in
+  migration-plan.md, verified before engagement close) confirming the same change is
+  merged upstream; (4) if the customer has config drift detection (Ansible periodic runs,
+  GitOps reconciliation like ArgoCD), an unmerged on-host edit isn't a risk, it's a
+  countdown — reconciliation intervals are often minutes. Confirm the reconciler is
+  paused for the window or the merge lands first.
+
+- **Command-line args / env override bundled config** (Spring Boot `--spring.datasource.url`
+  overrides `application-prod.properties`). Change the **highest-priority** source — often the
+  systemd `ExecStart` line. Back up the unit first (`cp unit unit.bak.$(date +%s)`), then
+  `systemctl daemon-reload`.
+- **Verify the secret actually contains `host`.** If it holds only `username`/`password`, the
+  Secrets Manager rotation method **alone will not repoint the app** — you must change the
+  config/unit and backfill `host`/`port`/`dbname`/`engine` into the secret.
+- **ALWAYS use the RDS DNS endpoint, never a resolved IP** — Multi-AZ failover keeps the DNS name
+  but changes the underlying IP.
+- **ORM auto-DDL:** if a client runs `spring.jpa.hibernate.ddl-auto=update` (or Rails/Django/
+  Sequelize auto-migrate), its first connection to the new DB may attempt schema changes — set
+  `validate`/`none` for production migrations.
+
+### Step 3 — Cross-check live connections from the DB side
+```sql
+SELECT user, SUBSTRING_INDEX(host,':',1) AS client_ip, db, command, COUNT(*) AS conns
+FROM information_schema.processlist GROUP BY user, client_ip, db, command;
+```
+Confirm the client IPs/counts match Steps 1–2. Any unexpected IP is a client you were about to miss.
+`Binlog Dump` / walsender sessions in this output are **replication consumers** — handle
+them in Step 4, not as app clients.
+
+### Step 4 — Downstream replication/CDC consumers (not app clients, still break at cutover)
+
+Anything reading the source's **binlog/WAL** — Debezium/Kafka Connect, downstream read
+replicas, BI sync tools (Fivetran/Airbyte), custom binlog readers, audit forwarders —
+stops working when the source freezes, and **cannot simply be repointed**: the target's
+binlog/LSN positions are different coordinates. Plan per consumer:
+
+| Consumer | Cutover plan |
+|----------|--------------|
+| Debezium / Kafka Connect | Stop the connector at freeze; deploy a NEW connector against the target with `snapshot.mode` appropriate to whether the topic can tolerate a re-snapshot (`schema_only` + fresh offsets if not); accept the offset reset — never copy old offsets. |
+| Downstream MySQL/PG replicas of the source | Rebuild them as replicas/readers of the new target (Aurora readers usually replace them outright — often the simpler answer). |
+| SaaS ELT (Fivetran/Airbyte/…) | Update the connection to the target endpoint; trigger a re-sync/historical re-load; verify the tool supports Aurora as a CDC source (binlog retention: `binlog retention hours` ≥ its sync interval). |
+| Custom binlog/WAL readers | Treat like Debezium: restart from the target's current position; reconcile any gap from the freeze window at the application level. |
+
+Record each consumer + its plan in the `migration-plan.md` client inventory (they get
+their own rows).
+
+### Completion criterion
+EVERY discovered client is repointed to the new RDS DNS endpoint and verified connected
+(bidirectionally — app health + DB-side processlist), and every replication/CDC consumer
+has executed its Step 4 plan.
+
+---
+
+## Method 1: Secrets Manager Rotation (Recommended)
+
+**Best for:** Applications that read DB credentials from AWS Secrets Manager.
+
+**Downtime:** 0-30 seconds (depends on application connection pool refresh interval)
+
+### Procedure
+
+```bash
+# Step 1: Verify CDC is caught up
+aws dms describe-replication-tasks \
+  --filters Name=replication-task-arn,Values=$TASK_ARN \
+  --query 'ReplicationTasks[0].ReplicationTaskStats.{
+    CDCLatencySource: CdcLatencySource,
+    CDCLatencyTarget: CdcLatencyTarget,
+    TablesLoaded: TablesLoaded,
+    TablesErrored: TablesErrored
+  }'
+# Verify: CDCLatencySource < 5, CDCLatencyTarget < 5, TablesErrored = 0
+
+# Step 2: Put application in read-only mode (disable write endpoints / feature flag)
+
+# Step 3: FREEZE THE SOURCE — mandatory, prevents split-brain. Any write that reaches the
+# source after this point would be lost (forward CDC is about to stop).
+#
+# PREREQUISITE for the read_only method: SUPER or READ_ONLY ADMIN privilege. A plain `admin`
+# account frequently lacks it and SET GLOBAL read_only returns:
+#   ERROR 1227 (42000): Access denied; you need (at least one of) the SUPER, READ_ONLY ADMIN privilege(s)
+#
+# 3a. PREFERRED (have the privilege): freeze the engine read-only.
+mysql -h $SOURCE_HOST -u admin -p -e \
+  "SET GLOBAL read_only = ON; SET GLOBAL super_read_only = ON;"
+mysql -h $SOURCE_HOST -u admin -p -e "SELECT @@global.read_only, @@global.super_read_only;"
+# PostgreSQL equivalent (new sessions only; also revoke INSERT/UPDATE/DELETE at app role):
+#   ALTER DATABASE your_db SET default_transaction_read_only = on;
+#
+# 3b. FALLBACK (no privilege — equally valid first-class option): QUIESCE by stopping write clients.
+# Stop ALL write clients discovered in the client-discovery step FIRST, then PROVE writers = 0:
+#   sudo systemctl stop backend.service   # (and every other write client)
+mysql -h $SOURCE_HOST -u admin -p -e "
+  SELECT id, user, SUBSTRING_INDEX(host,':',1) AS ip, db, command, info
+  FROM information_schema.processlist
+  WHERE command NOT IN ('Sleep','Daemon','Binlog Dump') AND info IS NOT NULL;"
+# Expect ZERO active write/DML threads. Stopping the clients becomes the freeze mechanism.
+
+# Step 4: Wait for final CDC drain (10-30 seconds), then re-verify CDC latency = 0
+sleep 30
+
+# Step 5: Stop forward DMS task (source → target)
+aws dms stop-replication-task --replication-task-arn $TASK_ARN
+
+# Step 6: Run final validation
+# (row count spot-check on 3-5 critical tables)
+
+# Step 7: RESET TARGET HIGH-WATER MARKS — AUTO_INCREMENT / sequences are NOT carried by
+# DMS or binlog CDC. Without this, the first inserts on Aurora collide with existing PKs.
+# MySQL/MariaDB — emit ALTER statements for every auto_increment column and run them:
+mysql -h $AURORA_ENDPOINT -u admin -p -N -e "
+  SELECT CONCAT('ALTER TABLE \`', t.TABLE_NAME, '\` AUTO_INCREMENT = ',
+                IFNULL((SELECT MAX(\`', k.COLUMN_NAME, '\`) FROM \`', t.TABLE_NAME, '\`),0)+1, ';')
+  FROM information_schema.TABLES t
+  JOIN information_schema.COLUMNS k
+    ON k.TABLE_SCHEMA = t.TABLE_SCHEMA AND k.TABLE_NAME = t.TABLE_NAME
+   AND k.EXTRA LIKE '%auto_increment%'
+  WHERE t.TABLE_SCHEMA = 'your_db';" | mysql -h $AURORA_ENDPOINT -u admin -p your_db
+# PostgreSQL — re-seed every owned sequence to its column max:
+#   SELECT setval(seq, COALESCE(max_val, 1)) for each sequence via pg_get_serial_sequence.
+
+# Step 8: START REVERSE REPLICATION (Aurora → source) — task created & connection-tested
+# pre-cutover but NEVER RUN (see "Reverse Replication — Set Up BEFORE Cutover" below).
+# This keeps the source a current standby for a lossless rollback.
+#
+# CDC START POSITION MATTERS: the reverse task must begin at the FREEZE POINT (now), not
+# at some earlier checkpoint — an earlier start would replay forward-load rows back at the
+# source. For a never-run task, starting it now (post-freeze, pre-app-writes) achieves
+# exactly that: Aurora's binlog contains no committed writes between freeze and repoint.
+# Pin it explicitly if you want belt-and-braces:
+#   --cdc-start-position "$(mysql -h $AURORA_ENDPOINT ... -N -e 'SHOW BINARY LOG STATUS' | awk '{print $1":"$2}')"
+aws dms start-replication-task \
+  --replication-task-arn $REVERSE_TASK_ARN \
+  --start-replication-task-type start-replication
+# (If the reverse task HAS run before — e.g. a full rehearsal on this same pair — do NOT
+# resume it: 'resume-processing' would continue from the rehearsal checkpoint. Delete and
+# recreate the task, or use 'reload-target'-free restart with an explicit --cdc-start-position.)
+
+# Step 9: Rotate the secret
+aws secretsmanager update-secret \
+  --secret-id "your-app/db-credentials" \
+  --secret-string '{
+    "username": "admin",
+    "password": "'"$DB_PASSWORD"'",
+    "host": "'"$AURORA_ENDPOINT"'",
+    "port": "3306",
+    "dbname": "your_db",
+    "engine": "mysql"
+  }'
+
+# Step 10: Force credential refresh (application-specific)
+# For Spring Boot with Secrets Manager rotation:
+#   - Connections auto-refresh based on maxLifetime setting
+# For ECS tasks:
+#   - aws ecs update-service --force-new-deployment triggers refresh
+# For Lambda:
+#   - Next invocation picks up new secret automatically
+
+# Step 11: Verify connectivity BIDIRECTIONALLY (single-direction curl is NOT sufficient).
+# (a) App side — health endpoint shows the DB up:
+curl -s https://your-app.example.com/actuator/health | jq '.components.db.status'   # "UP"
+# (b) DB side — the NEW DB's processlist shows the expected client IPs + connection count:
+mysql -h $AURORA_ENDPOINT -u admin -p -e "
+  SELECT SUBSTRING_INDEX(host,':',1) AS client_ip, db, COUNT(*) AS conns
+  FROM information_schema.processlist GROUP BY client_ip, db;"
+# Confirm every discovered client IP appears with a sane connection count (≈ the app pool size).
+# A green /health alone can mask a client that never repointed to the new endpoint.
+
+# Step 12: Re-enable writes (clear maintenance mode)
+```
+
+### Reverse Replication — Set Up BEFORE Cutover (mandatory for lossless rollback)
+
+The 7-day rollback window only protects you if the source stays current with the writes
+Aurora accepts after cutover. Establish a reverse CDC channel **before** the cutover window:
+
+```bash
+# Pre-cutover: create (but do NOT start) a reverse task with Aurora as source.
+aws dms create-replication-task \
+  --replication-task-identifier reverse-aurora-to-source \
+  --source-endpoint-arn $AURORA_ENDPOINT_ARN \
+  --target-endpoint-arn $SOURCE_ENDPOINT_ARN \
+  --replication-instance-arn $DMS_INSTANCE_ARN \
+  --migration-type cdc \
+  --table-mappings file://table-mappings.json \
+  --replication-task-settings file://reverse-task-settings.json
+# Verify BOTH endpoint connections (aws dms test-connection) — but do NOT start the task:
+# a task that has run holds a CDC checkpoint, and resuming from a pre-cutover checkpoint
+# at cutover would replay forward-load writes back into the source. Keep it never-run;
+# it is STARTED (fresh, from the freeze point) at cutover step 8.
+```
+
+- **MySQL/MariaDB**: Aurora's cluster parameter group needs `binlog_format=ROW` so the
+  source can consume Aurora's binlog as a replica.
+- **PostgreSQL**: Aurora needs `rds.logical_replication=1` and the source needs a free slot.
+- Native binlog/logical replication is an alternative to a reverse DMS task — pick whichever
+  matches the forward method.
+
+### When Reverse Replication is NOT Possible
+
+Reverse replication is the ideal lossless-rollback mechanism, but it is **impossible** under
+several real conditions. Do not require it as the only rollback path:
+
+| Condition | Why it fails |
+|-----------|--------------|
+| Source `log_bin=OFF` (not enabled) | No binlog for a reverse CDC channel to consume/target. |
+| Major version **downgrade** (target newer, e.g. 10.11 → 10.5) | Replicating back from newer to older major is unsupported/unreliable. |
+| Insufficient privileges | No `REPLICATION SLAVE`/`SUPER` (or PG replication role) to establish the channel. |
+
+**Alternatives (pick per RPO):**
+1. **Application-level write logging** — append every post-cutover write to a durable log
+   (append-only table on Aurora, SQS/Kinesis, structured request logs); replay against the source
+   on rollback. Closest to lossless.
+2. **Shortened sync window** — cut over immediately after the final sync/validation in a
+   low-traffic window so the stranded-write loss window is minimal.
+3. **Accept the risk with explicit RPO acknowledgment** (low-traffic/non-critical only) — state
+   plainly that rollback loses post-cutover Aurora writes, get explicit sign-off, keep the window
+   short. Record the acknowledgment in `migration-plan.md`.
+
+### Connection Pool Settings for Fast Refresh
+
+Set these **before** the cutover window (Phase 7.5 prep), targeting ~30-second recycle —
+the full per-pool table and rationale are in §"Minimize the Write-Pause Window" below.
+
+**HikariCP (Java/Spring Boot):**
+```yaml
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      max-lifetime: 30000     # 30s pre-cutover value — repoint takes effect within 30s
+      keepalive-time: 30000
+      connection-timeout: 5000
+      validation-timeout: 5000
+```
+Restore `max-lifetime` to its normal production value (e.g. 30 min) after the T+24h watch.
+
+**Node.js (mysql2/pg):**
+```javascript
+const pool = mysql.createPool({
+  connectionLimit: 20,
+  waitForConnections: true,
+  maxIdle: 5,
+  idleTimeout: 30000,   // 30s pre-cutover value
+});
+// After secret rotation, destroy and recreate pool to force immediate re-resolution
+pool.end(() => { /* recreate with new credentials */ });
+```
+
+---
+
+## Method 2: RDS Blue/Green Deployment
+
+**Best for:** Migrations from RDS MySQL/PostgreSQL to Aurora (already on RDS).
+
+**Downtime:** Typically < 1 minute (managed by AWS)
+
+### Procedure
+
+```bash
+# Step 1: Create Blue/Green deployment
+aws rds create-blue-green-deployment \
+  --blue-green-deployment-name "mysql-to-aurora" \
+  --source "arn:aws:rds:region:account:db:source-rds-instance" \
+  --target-engine-version "8.0.mysql_aurora.3.07.1" \
+  --target-db-cluster-parameter-group-name "aurora-mysql-params"
+
+# Step 2: Wait for green environment to be ready and synchronized
+aws rds describe-blue-green-deployments \
+  --blue-green-deployment-identifier $BGD_ID
+# Status should be: AVAILABLE, SwitchoverDetails.Status: AVAILABLE
+
+# Step 3: Switchover (AWS handles the cutover)
+aws rds switchover-blue-green-deployment \
+  --blue-green-deployment-identifier $BGD_ID \
+  --switchover-timeout 300
+
+# Step 4: Verify (endpoint names are swapped — application sees no change)
+# The original endpoint now points to Aurora
+
+# Step 5: Delete blue environment (after monitoring period)
+aws rds delete-blue-green-deployment \
+  --blue-green-deployment-identifier $BGD_ID \
+  --delete-target false  # Keep the old instance for rollback
+```
+
+**Limitations:**
+- Only works when source is already on RDS (not EC2)
+- Cross-engine only supported for MySQL → Aurora MySQL
+- PostgreSQL Blue/Green doesn't support cross-engine (PG → Aurora PG)
+
+---
+
+## Method 3: DNS CNAME Swap (Route 53)
+
+**Best for:** Applications using DNS hostnames for DB connectivity (not hardcoded IPs).
+
+**Downtime:** DNS TTL propagation time (set TTL to 60s before migration)
+
+### Procedure
+
+```bash
+# Step 1: Lower TTL 24 hours before cutover
+aws route53 change-resource-record-sets \
+  --hosted-zone-id $ZONE_ID \
+  --change-batch '{
+    "Changes": [{
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "db.internal.example.com",
+        "Type": "CNAME",
+        "TTL": 60,
+        "ResourceRecords": [{"Value": "source-db-host.example.com"}]
+      }
+    }]
+  }'
+
+# Step 2: At cutover time — swap CNAME to Aurora
+aws route53 change-resource-record-sets \
+  --hosted-zone-id $ZONE_ID \
+  --change-batch '{
+    "Changes": [{
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "db.internal.example.com",
+        "Type": "CNAME",
+        "TTL": 60,
+        "ResourceRecords": [{"Value": "your-cluster.cluster-xxxx.region.rds.amazonaws.com"}]
+      }
+    }]
+  }'
+
+# Step 3: Wait for TTL expiry (60 seconds)
+sleep 60
+
+# Step 4: Verify resolution
+dig db.internal.example.com CNAME
+# Should resolve to Aurora endpoint
+```
+
+**Limitations:**
+- Applications caching DNS beyond TTL will have extended downtime
+- Java applications with `networkaddress.cache.ttl` set high need JVM restart
+- Not suitable if applications use IP addresses directly
+
+---
+
+## Rollback Procedures
+
+### Quick Rollback (< 5 minutes) — Lossless when reverse replication is running
+
+Because reverse replication (Aurora → source) has been running since cutover, the source is
+current and failback loses no data. Rollback sequence:
+
+1. Set Aurora read-only: `SET GLOBAL read_only=ON; SET GLOBAL super_read_only=ON;`
+   (PostgreSQL: `ALTER DATABASE your_db SET default_transaction_read_only=on;`)
+2. Confirm reverse CDC drained to zero lag (`CdcLatencySource`/`CdcLatencyTarget` = 0), then
+   stop the reverse task.
+3. Reset AUTO_INCREMENT / sequences on the **source** above its new max (same query as
+   cutover step 7, run against the source) so resumed writes don't collide.
+4. Revert the secret / DNS to the source endpoint and refresh the app's connections.
+
+| Method | Rollback Action | Time |
+|--------|----------------|------|
+| Secrets Manager | Freeze Aurora → drain reverse CDC → revert secret to source | < 2 min + pool refresh |
+| Blue/Green | Create new B/G deployment to switch back | 5-10 min |
+| DNS CNAME | Freeze Aurora → drain reverse CDC → swap CNAME back | TTL (60s) |
+| DMS | Reverse task already running — just stop, then repoint app | < 2 min |
+
+> **If reverse replication was NOT set up**, rollback is lossy: every write Aurora accepted
+> after cutover is stranded on Aurora. Only acceptable if you can replay those writes from an
+> application-side log. This is exactly why reverse replication is mandatory above.
+
+### Rollback Decision Criteria
+
+| Signal | Severity | Action |
+|--------|----------|--------|
+| Application error rate > 5% | Critical | Immediate rollback |
+| P99 latency > 3x baseline | High | Rollback if not improving in 5 min |
+| Connection failures > 1% | High | Check SG/credentials first, rollback if not fixable in 10 min |
+| Data integrity concerns | Critical | Immediate rollback, investigate |
+| Single slow query | Low | Investigate — likely missing ANALYZE TABLE |
+
+### Post-Rollback Actions
+
+1. Keep Aurora cluster running (do NOT delete)
+2. Investigate root cause
+3. Fix the issue
+4. Re-plan cutover window
+5. Re-sync DMS (restart task with `--start-replication-task-type resume-processing`)
+
+---
+
+## Execute the Freeze Window as ONE Pre-Staged Script per Host
+
+A cutover driven as **interactive SSM send-command round-trips** adds 30–40 s of
+dispatch latency *per step group* inside the freeze window — easily turning ~40 s of
+actual DB work into a 300+ s write pause. Rules:
+
+1. **Pre-stage the whole freeze-window sequence as one script on each host** (delivered
+   during prep, verified with a `--dry-run` flag). At T-0 you issue ONE command per host,
+   not one per step.
+2. **Test every engine-specific command against the real target version before the
+   window.** Known trap: Aurora MySQL 8.0 uses `SHOW MASTER STATUS` / `STOP REPLICA`;
+   MySQL 8.4 renamed it `SHOW BINARY LOG STATUS`. A syntax error discovered mid-freeze
+   forces in-window debugging — exactly what the rehearsal exists to prevent.
+3. **Time-budget each step from the rehearsal** and put the numbers in the runbook; a step
+   exceeding 2× its budget is an abort signal, not a "keep fiddling" signal.
+
+## Minimize the Write-Pause Window (pre-cutover prep)
+
+
+For "absolute minimal downtime" EC2 → RDS/Aurora, the cutover pause is the time between *freezing the source* and *the app writing to the target*. CDC catch-up (matrix rows 6–7 — XtraBackup seed + binlog/CDC catch-up, DMS Full Load + CDC — and their Oracle analog, row 15's Data Pump seed + DMS CDC) is what makes this a **pause measured in seconds, not the whole transfer** — the bulk load runs while the app stays up, and only the final CDC drain happens inside the window. Shrink that window with these prep steps:
+
+**1. Connection-pool settings — set BEFORE cutover (not at cutover).** A stale pool keeps connections open to the old DB long after you repoint, stretching the effective pause. Tune the pool so it recycles fast:
+
+| Pool | Pre-cutover setting | Effect |
+|------|---------------------|--------|
+| **HikariCP** (Spring Boot) | `maxLifetime=30000` (30s), `keepaliveTime=30000`, `validationTimeout=5000` | Connections recycle within 30s, so a Secrets-Manager/DNS repoint takes effect in ≤30s without a restart. Also set `connectionTimeout` low so failover fails fast rather than hanging. |
+| **HikariCP — force immediate** | `dataSource.evictConnections()` / `HikariPoolMXBean.softEvictConnections()` via JMX at cutover | Drops idle connections now instead of waiting out `maxLifetime` — turns the 30s wait into ~immediate. |
+| **PgBouncer** | `RECONNECT;` then `RELOAD;` on the admin console (or `server_lifetime` low) after changing the upstream `host=` in `pgbouncer.ini` | New server connections go to the target; existing ones drain. App pool need not restart. |
+| **Node (`mysql2`/`pg`) pool** | low `idleTimeoutMillis` / `maxLifetime`; call `pool.end()` + recreate at cutover | Forces re-resolution of the new endpoint. |
+
+Document the chosen values in `migration-plan.md` as a Phase 7.5 / pre-cutover prep item.
+
+**2. Coordinated vs. rolling restart — pick deliberately.**
+
+- **Coordinated (all-at-once) restart** — stop every write client, repoint, start them all. **Fastest total pause (~10s)** and there is **no split-brain window** because no client is writing during the swap. Use this when a brief full write-pause is acceptable (the default for minimal-downtime cutovers). This is faster than waiting on Secrets Manager pool TTL (up to ~5 min) — change the config/unit and restart directly.
+- **Rolling restart** (restart instances one at a time behind a load balancer) — keeps *some* capacity serving, so no hard outage, **but** during the roll some instances point at the old DB and some at the new one → **split-brain writes**. Only safe if the source is already frozen read-only (cutover step 3) *before* the roll begins, so stragglers can't write the old DB. Prefer coordinated restart for write workloads; reserve rolling for read-heavy/stateless tiers.
+
+**3. Deploy RDS Proxy on the TARGET before cutover.** The initial EC2 → RDS/Aurora cutover still incurs the brief pause above — **RDS Proxy does not eliminate the *initial* cutover pause** — but standing it up *before* cutover pays off two ways: (a) point the app at the **proxy endpoint** at cutover instead of the cluster endpoint, so all *future* failovers/maintenance are handled by the proxy (it holds the client connections and reconnects to the new writer in **< 1s, no app restart, no pool refresh**); and (b) the proxy multiplexes the reconnect storm at cutover, so the pool refresh doesn't hammer the new DB. After this migration, failovers become effectively zero-downtime even though *this* cutover paused briefly. (Provision it in Phase 4 — see "RDS Proxy on the target".) Note: true Blue/Green sub-second switchover requires the source to **already be on RDS/Aurora** — it's for RDS→Aurora upgrades, not this initial EC2→RDS move.

--- a/db-migration-agent-skill/shared/reference/dms-best-practices.md
+++ b/db-migration-agent-skill/shared/reference/dms-best-practices.md
@@ -1,0 +1,135 @@
+# DMS Best Practices — Quick Reference
+
+## Replication Instance Sizing
+
+| Workload | Instance | RAM | Use Case |
+|----------|----------|-----|----------|
+| Dev/Test | dms.r6i.large | 16 GB | < 50 tables, testing |
+| Small Production | dms.r6i.xlarge | 32 GB | 50-300 tables, < 500 GB |
+| Medium Production | dms.r6i.2xlarge | 64 GB | 300-1000 tables, LOBs present |
+| Large Production | dms.r6i.4xlarge | 128 GB | 1000+ tables, > 2 TB |
+
+**Rules:**
+- Allocate 50-70% of RAM for `MemoryLimitTotal`
+- Never use T-family for production (CPU credit exhaustion)
+- Start larger during full load, scale down for steady-state CDC
+- Multi-AZ for production migrations (auto-failover)
+
+## LOB Handling
+
+| Mode | Max Size | Performance | Use When |
+|------|----------|-------------|----------|
+| Limited LOB | Configurable (e.g., 32 KB) | Fast (inline transfer) | LOB sizes are predictable and bounded |
+| Full LOB | Unlimited | Slow (2 lookups per row) | LOBs vary wildly in size |
+| Inline LOB | Configurable threshold | Best of both | Mixed LOB sizes (small + occasional large) |
+
+**Query to profile LOB sizes:**
+```sql
+-- MySQL: Find actual max LOB sizes
+SELECT table_name, column_name,
+  MAX(LENGTH(column_name)) AS max_bytes
+FROM your_db.your_table GROUP BY table_name, column_name;
+```
+
+**Recommendation:** Use Limited LOB Mode with `LobMaxSize` set to the 99th percentile of your actual LOB sizes. Only use Full LOB mode if you cannot afford to truncate any LOBs.
+
+## Task Types
+
+| Type | Downtime | Prerequisites | Migrates Views? |
+|------|----------|---------------|-----------------|
+| Full Load Only | Yes (duration = data size / throughput) | None | ✅ Yes |
+| CDC Only | No (ongoing) | Data must already exist on target | ❌ No |
+| Full Load + CDC | Near-zero (seconds at cutover) | Binary logging / logical replication | ❌ No (tables only) |
+
+## Critical Settings
+
+### Full Load Optimization
+```json
+{
+  "MaxFullLoadSubTasks": 16,
+  "CommitRate": 50000,
+  "TargetTablePrepMode": "DROP_AND_CREATE",
+  "CreatePkAfterFullLoad": true
+}
+```
+
+`CreatePkAfterFullLoad: true` — creates primary keys AFTER data load, significantly speeding up full load (no index maintenance during bulk insert).
+
+### CDC Optimization
+```json
+{
+  "BatchApplyEnabled": true,
+  "BatchApplyPreserveTransaction": true,
+  "BatchApplyTimeoutMax": 30,
+  "MinTransactionSize": 1000
+}
+```
+
+`BatchApplyEnabled: true` — groups changes into batches instead of applying one-by-one. 2-5x throughput improvement.
+
+## What DMS Does NOT Migrate
+
+| Object Type | Alternative |
+|-------------|-------------|
+| Stored procedures | mysqldump --routines / pg_dump --schema-only |
+| Triggers | mysqldump --triggers / pg_dump |
+| Views | Full Load task only, OR mysqldump |
+| Functions | mysqldump --routines / pg_dump |
+| Events (MySQL) | mysqldump --events |
+| Sequences (PostgreSQL) | pg_dump --schema-only |
+| Indexes (optionally) | Created after full load for speed |
+| User permissions/grants | Manual recreation |
+| Custom data types (PG) | pg_dump --schema-only |
+
+## Pre-Migration Assessment
+
+Always run the DMS pre-migration assessment before starting:
+```bash
+aws dms create-replication-task \
+  --replication-task-identifier "assessment-task" \
+  --source-endpoint-arn $SOURCE_ARN \
+  --target-endpoint-arn $TARGET_ARN \
+  --replication-instance-arn $INSTANCE_ARN \
+  --migration-type "full-load" \
+  --table-mappings file://table-mappings.json \
+  --enable-premigration-assessment-run
+```
+
+This checks:
+- Source DB connectivity and permissions
+- Unsupported data types
+- Tables without primary keys (affects CDC validation)
+- LOB column identification
+- Binary logging configuration (MySQL)
+- Replication slot availability (PostgreSQL)
+
+## Monitoring Metrics
+
+| Metric | Warning Threshold | Action |
+|--------|------------------|--------|
+| CDCLatencySource | > 30 seconds | Check source load, increase instance |
+| CDCLatencyTarget | > 30 seconds | Enable BatchApply, scale target |
+| FreeableMemory | < 2 GB | Scale up replication instance |
+| SwapUsage | > 0 | Instance is undersized |
+| CPUUtilization | > 80% sustained | Scale up or reduce parallelism |
+
+## Engine-Specific Gotchas
+
+### MySQL → Aurora MySQL
+- `DEFINER` clauses in views/procedures may fail if the user doesn't exist on Aurora
+- `SUPER` privilege not available on Aurora — use `rds_superuser_role` or remove DEFINER
+- AUTO_INCREMENT values may differ slightly after CDC (higher on target is OK)
+- `sql_mode` differences between versions can cause trigger/procedure failures
+
+### MariaDB → Aurora MySQL
+- MariaDB-specific SQL syntax (e.g., `RETURNING` clause) not supported in Aurora MySQL
+- Sequence objects (MariaDB 10.3+) not available in Aurora MySQL — use AUTO_INCREMENT
+- System-versioned tables (temporal tables) not supported in Aurora MySQL
+- GIS spatial functions differ between MariaDB and MySQL 8.0
+
+### PostgreSQL → Aurora PostgreSQL
+- Not all extensions are available on Aurora (check `SELECT * FROM pg_available_extensions`)
+- `pg_cron` requires Aurora-specific setup
+- Large objects (lo) need special handling in DMS
+- Custom C-language functions cannot be installed on Aurora
+- Replication slots MUST be cleaned up to prevent WAL accumulation

--- a/db-migration-agent-skill/shared/reference/engagement-safety.md
+++ b/db-migration-agent-skill/shared/reference/engagement-safety.md
@@ -1,0 +1,125 @@
+# Engagement Modes, Criticality Tiers & Production Safety
+
+> Read this at **Phase 0** — before the first customer question. It defines the two
+> decisions that shape the entire engagement (mode and tier), the ceremony each tier
+> requires, the waiver protocol, and the IAM guardrails. The failure mode this file
+> prevents: not teams doing too little ceremony on purpose, but teams **not realizing
+> which tier they're actually in**.
+
+## Engagement modes (chosen at Phase 0 — the FIRST question)
+
+An engagement is exactly one of these; each is separately scoped and approved. The mode
+determines what the session is even *allowed* to do.
+
+| Mode | What happens | What physically limits it | Deliverable |
+|------|--------------|---------------------------|-------------|
+| **assessment-only** | Phases 0–3 as read-only analysis: preflight, discovery, full compatibility/blocker scan, sizing, client discovery, third-party sweep, method recommendation, cost | Read-only DB user granted by the customer + read-only IAM session (see §IAM guardrails). The mode **cannot write** — a blocker like a failing trigger becomes a *finding in the report*, not an action | Assessment report + draft `migration-plan.md` + risk register + cost estimate |
+| **staging-rehearsal** | The full migration executed against a **clone restored from a snapshot** — never production. Measures the real cutover window | Operates only on clone resources tagged for the rehearsal; production endpoints never appear in cutover scripts | Rehearsal report with **measured** step timings → the time budget quoted for production |
+| **production-migration** | The real thing, Phases 0–9 | **Locked unless an assessment report exists** (this engagement or a prior one). Rehearsal expectations set by tier (below). IAM guardrail policy active | Migrated database + full audit record |
+
+Mode rules:
+- Ask the mode question before anything else; record it in `migration-plan.md` header
+  and `authorizations.md` §1.
+- A customer asking to "just migrate it" without a prior assessment → run the assessment
+  phases first inside the production engagement (Phases 1–3 are the assessment), and say
+  so; the point is the *report exists and was approved*, not bureaucracy.
+- Mode transitions (assessment → production) are new approvals, not silent upgrades.
+
+## Criticality tiers (chosen at Phase 1 discovery, locked at GATE 1)
+
+Ask, with the guidance below — customers habitually under-tier:
+
+> "If this database is wrong or unavailable for an hour, what happens? Nobody notices
+> until Monday → Tier 1. Revenue stops or customers see errors → Tier 2. Regulatory
+> breach, financial reconciliation breaks, or the company makes the news → Tier 3."
+
+| | **Tier 1 — Standard** | **Tier 2 — Business-critical** (default) | **Tier 3 — Mission-critical** |
+|---|---|---|---|
+| Typical workload | Internal tools, dev/stage DBs, small sites | Order systems, SaaS backends, the main app DB | Payments, ledgers, regulated data, tenant platforms |
+| Rehearsal | Recommended; waivable with recorded waiver | **1 full rehearsal required** (staging-rehearsal mode or clone inside the engagement) | **Repeated timed rehearsals until the measured window converges** (< 20% delta between consecutive runs) |
+| Soak (Phase 7.7) | Not required | **Required** — default 7 consecutive green days (customer picks N ≥ 3) | Required — N ≥ 7, **plus performance validation**: top-N plan diffs vs baseline AND customer load test or read-only production traffic against the target |
+| Validation depth | Row counts + checksums + smoke test | + app-level checks, version-gap battery if applicable, **+ customer's own test suite against the target (Q18) when one exists** | + **daily reconciliation reports** (domain aggregates, e.g. financial totals, agreed with the customer) + customer test suite required — no suite = a recorded waiver |
+| Rollback | Snapshot restore acceptable **with explicit RPO acknowledgment** | Reverse replication required (or write-log replay + RPO sign-off where impossible) | Reverse replication required; phased cutover option offered (reads first, then writes; or service-by-service) |
+| Cutover approval | Named approver in `authorizations.md` | Named approver + agreed abort criteria | Named approver **present during the window** (war-room), executive sign-off row |
+| Waivers | Recorded | Recorded + named approver | Recorded + named approver + rationale; agent must restate the risk in one plain sentence |
+
+The agent **enforces this matrix**: a Tier-2 cutover with zero rehearsals and no waiver
+row is a blocked action, not a judgment call.
+
+## Waiver protocol
+
+When the customer declines any tier requirement (rehearsal, soak length, reverse
+replication):
+1. State plainly, in one or two sentences, what risk moves into the production window.
+2. Record the waiver in `authorizations.md` §Waivers — what was skipped, the risk as
+   stated, who accepted it, date.
+3. Recover what value you can (e.g. declined rehearsal → component-test every
+   freeze-window command against the real target; see execution-runbooks.md §Rehearsal).
+4. Never silently skip. A waiver the customer doesn't remember signing is a failure.
+
+Why this matters: a declined rehearsal plus one untested engine-version-specific
+command is all it takes to turn a 40-second freeze into a 5-minute write pause.
+
+## Approvals of record
+
+Chat approvals drift and scroll away. Every gate sign-off, action-class authorization,
+and waiver lives in **`authorizations.md`** (template in `shared/templates/`), with a
+named person and date. `migration-plan.md` gate rows point at the corresponding
+authorization row. The customer can hand the file to an auditor.
+
+Action classes requiring a row **before** first execution:
+1. Read-only source access (assessment)
+2. Source writes (blocker fixes, migration user creation — each listed individually)
+3. Target/production infrastructure deploys
+4. Cutover execution (window + runbook version)
+5. Rollback execution (pre-authorized criteria vs ad-hoc)
+6. Decommission (exact resource list)
+
+## IAM guardrails
+
+Generate a **session policy** for the operator role per engagement and record it in the
+plan. Structure:
+
+- **assessment-only**: allow only `Describe*`/`Get*`/`List*` on the relevant services +
+  `ssm:StartSession`/`SendCommand` scoped to the source instances (needed to run
+  read-only SQL). No `Create*`, no `Modify*`, no `secretsmanager:PutSecretValue`.
+- **staging-rehearsal / production-migration**: the operator set from
+  [preflight-iam-cost.md](preflight-iam-cost.md) §2, **plus explicit Denies that outlast
+  any agent mistake** until the decommission stage is signed:
+
+```json
+{
+  "Sid": "ProtectSourceUntilDecommission",
+  "Effect": "Deny",
+  "Action": [
+    "ec2:TerminateInstances", "ec2:StopInstances",
+    "rds:DeleteDBCluster", "rds:DeleteDBInstance",
+    "rds:DeleteDBSnapshot", "ec2:DeleteVolume"
+  ],
+  "Resource": ["<source-instance-arn>", "<source-volume-arns>", "<target-cluster-arn>"]
+}
+```
+
+- At decommission (Phase 9, after the signed authorization), the session policy is
+  re-issued without the Deny — the *policy change itself* is the two-person control.
+- Where session policies aren't practical (customer-provided credentials), fall back to
+  an SCP-style permissions boundary or, minimally, `aws iam simulate-principal-policy`
+  proof that the destructive actions are denied — and record which control is in place.
+- **The fallback chain is acceptable, not a blocker.** When the customer cannot provision
+  roles or attach policies on the engagement's timeline (common), the combination of
+  (a) simulate-proof of what *would* be denied, (b) a customer-recorded procedural
+  constraint ("read-only user only, no mutating calls"), and (c) the CloudTrail audit
+  trail **is a valid guardrail for assessment-only mode**. State which level is in force
+  and move on — do not stop the engagement demanding IAM changes the customer already
+  declined. (Production-migration mode should still push harder for a hard control.)
+
+## How this maps onto the phases
+
+| Phase | Addition |
+|-------|----------|
+| 0 | Mode question first; mode gates the whole session; guardrail policy generated |
+| 1 / GATE 1 | Tier question (with the under-tiering guidance); mode + tier locked and signed in `authorizations.md` |
+| 6.5 | Rehearsal per tier (see execution-runbooks.md §Rehearsal; Tier 3 repeats until convergence) |
+| **7.7 (new)** | **Parallel-run soak** (Tier 2/3): target stays CDC-current; daily `soak-report.md`; customer may point read-only traffic/load tests at the target; **cutover stays locked until N consecutive green days + signed cutover authorization** |
+| 8 / GATE 4 | Cutover authorization row required; Tier 3 approver present |
+| 9 | Decommission authorization row; guardrail Deny lifted only after it |

--- a/db-migration-agent-skill/shared/reference/execution-runbooks.md
+++ b/db-migration-agent-skill/shared/reference/execution-runbooks.md
@@ -1,0 +1,428 @@
+# Execution Runbooks — Method-Specific Migration Procedures
+
+> Read the section for the **approved method only** during **Phase 6 (Execute)**.
+> Covers: mysqldump/pg_dump, Percona XtraBackup + S3, DMS Full Load + CDC, Aurora Read
+> Replica, Blue/Green, Oracle Data Pump via S3, SQL Server native backup/restore,
+> schema-object migration (DEFINER stripping, logins/Agent jobs, TDE certificates), and
+> the pre-production rehearsal. DMS deep configuration: [dms-best-practices.md](dms-best-practices.md).
+
+## Method-Specific Procedures
+
+### If mysqldump / pg_dump (small DBs, downtime OK)
+
+```bash
+# MySQL: Full export including all schema objects
+mysqldump --single-transaction --routines --triggers --events \
+  --set-gtid-purged=OFF --column-statistics=0 \
+  -h $SOURCE_HOST -u admin -p your_db > full_dump.sql
+
+# Import to Aurora
+mysql -h $AURORA_ENDPOINT -u admin -p your_db < full_dump.sql
+```
+
+> **Logical dump = a clean major-version-upgrade opportunity.** Because mysqldump/pg_dump re-import the data from scratch, the target can be a **newer major version** than the source (e.g. MariaDB 10.5 → 10.11, MySQL 5.7 → 8.0, PostgreSQL 13 → 16) in the *same* migration — no separate upgrade project. Validate with `CHECKSUM TABLE` that bytes are identical across the version gap (they were 10.5→10.11 in the reference migration). **But version gaps introduce behavioral changes** — reserved-word additions, deprecated/removed functions, changed defaults (charset, sql_mode, auth plugin). Review **[version-upgrades.md](version-upgrades.md)** before choosing the target version. (Physical methods — XtraBackup, snapshot, Read Replica — cannot skip major versions; only logical dump can.)
+
+```bash
+# PostgreSQL: Parallel dump/restore
+pg_dump -Fd -j 8 -h $SOURCE_HOST -U postgres -d your_db -f /backup/
+pg_restore -Fd -j 8 -h $AURORA_ENDPOINT -U postgres -d your_db /backup/
+```
+
+### If Percona XtraBackup + S3 (large MySQL, physical)
+
+```bash
+# 1. Full backup
+export MYSQL_PWD=$(aws secretsmanager get-secret-value --secret-id $SECRET_ID --query SecretString --output text | python3 -c 'import sys,json;print(json.load(sys.stdin)["password"])')
+xtrabackup --backup --target-dir=/backup --user=admin
+
+# 2. Prepare backup
+xtrabackup --prepare --target-dir=/backup
+
+# 3. Upload to S3
+aws s3 sync /backup/ s3://your-bucket/xtrabackup/ --sse aws:kms
+
+# 4. Restore to Aurora (via console or CLI)
+aws rds restore-db-cluster-from-s3 \
+  --db-cluster-identifier your-aurora-cluster \
+  --engine aurora-mysql \
+  --engine-version 8.0.mysql_aurora.3.07.1 \
+  --s3-bucket-name your-bucket \
+  --s3-prefix xtrabackup/ \
+  --s3-ingestion-role-arn arn:aws:iam::ACCOUNT:role/aurora-s3-role \
+  --source-engine mysql \
+  --source-engine-version 8.0.36 \
+  --master-username admin \
+  --master-user-password $NEW_PASS
+```
+
+**Requirements:**
+- Source: MySQL 5.7 (XtraBackup 2.4) or MySQL 8.0 (XtraBackup 8.0)
+- `innodb_file_per_table` must be enabled
+- NO encrypted tablespaces (TDE must be off)
+- InnoDB page size must be 16 KB (default)
+
+### If DMS Full Load + CDC (zero-downtime)
+
+See [dms-best-practices.md](dms-best-practices.md) for complete DMS configuration including:
+- Replication instance sizing
+- Source/target endpoint configuration
+- Task settings (Full Load + CDC, parallel load, batch apply, LOB handling)
+- Table mappings
+- Monitoring
+
+**Key prerequisite for CDC:**
+- MySQL/MariaDB: `binlog_format=ROW`, `binlog_row_image=FULL`, `log_bin=ON`
+- PostgreSQL: `wal_level=logical`, available replication slots
+
+### If XtraBackup Seed + Binlog/DMS CDC Catch-up (large MySQL, minimal downtime — matrix row 6)
+
+Combine the two procedures above: the physical copy does the bulk, CDC closes the delta.
+
+```bash
+# 1. Take the XtraBackup exactly as in the previous section. The backup RECORDS the
+#    consistent binlog position itself — read it from the prepared backup dir:
+cat /backup/xtrabackup_binlog_info        # e.g.  mysql-bin.000042  1337  [gtid-set]
+
+# 2. Restore to Aurora via restore-db-cluster-from-s3 (previous section, steps 3-4).
+
+# 3. Catch up the delta from the RECORDED position — two equivalent channels:
+# 3a. Native binlog replication (Aurora as replica of the source):
+mysql -h $AURORA_ENDPOINT -u admin -p -e "
+  CALL mysql.rds_set_external_source ('$SOURCE_HOST', 3306, '$REPL_USER', '$REPL_PASS',
+       'mysql-bin.000042', 1337, 0);
+  CALL mysql.rds_start_replication;"
+#     Requires a REPLICATION SLAVE user on the source and binlog retention long enough
+#     to cover the bulk-copy + restore time: on the source,
+#     SET GLOBAL binlog_expire_logs_seconds ≥ (copy+restore hours × 3600) × 2.
+# 3b. Or a DMS CDC-only task with --cdc-start-position "mysql-bin.000042:1337".
+
+# 4. Monitor lag until ≈0 (SHOW REPLICA STATUS → Seconds_Behind_Source, or CDC metrics),
+#    then hold it running until the cutover window. At cutover (cutover-procedures.md):
+#    freeze source → lag=0 → CALL mysql.rds_stop_replication / stop the DMS task → proceed.
+```
+
+**The recorded position is the whole game** — a wrong or expired position means silent
+duplicate/missing rows. Record it in `migration-plan.md` the moment the backup completes.
+(Oracle equivalent: Data Pump seed with the SCN captured via `FLASHBACK_SCN`, then DMS CDC
+`--cdc-start-position` at that SCN — matrix row 15.)
+
+### If PostgreSQL Native Logical Replication (EC2/on-prem PG → Aurora PG, near-zero downtime — matrix row 11)
+
+Preferred over DMS for PG→PG: better datatype fidelity, no replication instance to run.
+Constraints to state up front: **sequences are NOT replicated** (re-seed at cutover — the
+high-water-mark step is mandatory), **DDL is not replicated** (freeze schema changes for
+the migration window), every table needs a PK or `REPLICA IDENTITY FULL`, and large
+objects (`lo`) are not carried.
+
+```bash
+# 0. Prerequisites — SOURCE postgresql.conf (restart if wal_level changes):
+#    wal_level=logical, max_replication_slots ≥ 2, max_wal_senders ≥ 2
+#    pg_hba.conf: allow replication connection from the Aurora VPC/SG path.
+#    TARGET Aurora PG cluster parameter group: rds.logical_replication=1 (reboot).
+
+# 1. Schema first (logical replication moves rows, not DDL):
+pg_dump --schema-only --no-owner --no-privileges -h $SOURCE -U postgres your_db \
+  | psql -h $AURORA_ENDPOINT -U postgres -d your_db
+
+# 2. On SOURCE: publication for all tables (or an explicit list):
+psql -h $SOURCE -U postgres -d your_db -c "CREATE PUBLICATION mig_pub FOR ALL TABLES;"
+
+# 3. On TARGET: subscription — initial data copy + streaming happen automatically:
+psql -h $AURORA_ENDPOINT -U postgres -d your_db -c "
+  CREATE SUBSCRIPTION mig_sub
+  CONNECTION 'host=$SOURCE port=5432 dbname=your_db user=repl_user password=...'
+  PUBLICATION mig_pub;"       # creates its own slot on the source
+
+# 4. Monitor: initial sync state per table, then ongoing lag:
+psql -h $AURORA_ENDPOINT -c "SELECT srsubstate, count(*) FROM pg_subscription_rel GROUP BY 1;"
+#    srsubstate: i=init, d=copying, s/r=synced+streaming — wait for all 'r'
+psql -h $SOURCE -c "SELECT slot_name, confirmed_flush_lsn,
+  pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn) AS lag_bytes
+  FROM pg_replication_slots;"
+
+# 5. At cutover (cutover-procedures.md order): freeze source → lag_bytes=0 →
+#    DISABLE the subscription (ALTER SUBSCRIPTION mig_sub DISABLE;) → re-seed sequences
+#    (setval per pg_get_serial_sequence) → repoint clients.
+
+# 6. AFTER the rollback window — drop subscription AND make sure the source slot is gone
+#    (an orphaned slot pins WAL on the source until the disk fills):
+psql -h $AURORA_ENDPOINT -c "DROP SUBSCRIPTION mig_sub;"
+psql -h $SOURCE -c "SELECT pg_drop_replication_slot(slot_name)
+  FROM pg_replication_slots WHERE slot_name LIKE '%mig_sub%' AND NOT active;"
+```
+
+Version note: source must be PG 10+; cross-major replication (13 → 16) is supported and
+is the standard near-zero-downtime major-upgrade path — run the
+[version-upgrades.md](version-upgrades.md) validation battery when crossing majors.
+
+### If Aurora Read Replica (RDS MySQL/PG → Aurora)
+
+```bash
+# From RDS MySQL → Aurora MySQL Read Replica
+aws rds create-db-cluster \
+  --db-cluster-identifier aurora-replica-cluster \
+  --engine aurora-mysql \
+  --replication-source-identifier arn:aws:rds:REGION:ACCOUNT:db:source-rds-instance
+
+# Wait for replica to sync, then promote
+aws rds promote-read-replica-db-cluster \
+  --db-cluster-identifier aurora-replica-cluster
+```
+
+**Only works from RDS (not EC2 directly).** For EC2 → Aurora, use DMS or XtraBackup.
+
+### If Blue/Green Deployment (RDS/Aurora in-place upgrade)
+
+```bash
+aws rds create-blue-green-deployment \
+  --blue-green-deployment-name "migrate-to-aurora" \
+  --source "arn:aws:rds:REGION:ACCOUNT:db:source-instance" \
+  --target-engine-version "8.0.mysql_aurora.3.07.1"
+
+# Wait for green to be AVAILABLE and synchronized, then:
+aws rds switchover-blue-green-deployment \
+  --blue-green-deployment-identifier $BGD_ID \
+  --switchover-timeout 300
+```
+
+### If Oracle Data Pump (Oracle → RDS Oracle, primary method)
+
+RDS Oracle has **no OS shell** — you cannot run `impdp`/`expdp` on the host. You either call **`DBMS_DATAPUMP`** from a SQL client, or run **`impdp` from a remote Oracle Instant Client** against the RDS endpoint. The dump moves to RDS via **S3 integration** (most common) or **`DBMS_FILE_TRANSFER` over a DB link**.
+
+> **Schema/table mode only — never FULL mode**, and never import SYS/SYSTEM/RDSADMIN-owned objects: a full-mode import can damage the data dictionary. RDS does not grant SYS/SYSDBA.
+
+**One-time setup — S3 integration:** attach an IAM policy (`s3:GetObject`, `s3:ListBucket`, `s3:PutObject`; add `s3:AbortMultipartUpload`+`s3:ListMultipartUploadParts` for ≥100 MB files; add `kms:Decrypt`/`Encrypt`/`GenerateDataKey`/`DescribeKey` for SSE-KMS buckets — bucket must be **same Region**, SSE-C not supported), associate the role for `S3_INTEGRATION`, and add the `S3_INTEGRATION` option to the option group:
+```bash
+aws rds add-role-to-db-instance --db-instance-identifier my-oracle-target \
+  --feature-name S3_INTEGRATION --role-arn arn:aws:iam::ACCT:role/rds-s3-integration-role
+aws rds add-option-to-option-group --option-group-name myoptiongroup \
+  --options OptionName=S3_INTEGRATION,OptionVersion=1.0 --apply-immediately
+```
+
+```sql
+-- 1. On TARGET (as master): create the schema + grants (schema mode)
+CREATE USER schema_1 IDENTIFIED BY "<password>";
+GRANT CREATE SESSION, RESOURCE TO schema_1;
+ALTER USER schema_1 QUOTA UNLIMITED ON users;
+```
+
+```sql
+-- 2. On SOURCE: export with DBMS_DATAPUMP (schema mode). EXCLUDE Scheduler objects
+--    owned by system schemas (importing those into RDS is unsupported).
+DECLARE v_hdnl NUMBER;
+BEGIN
+  v_hdnl := DBMS_DATAPUMP.OPEN(operation=>'EXPORT', job_mode=>'SCHEMA', job_name=>NULL);
+  DBMS_DATAPUMP.ADD_FILE(v_hdnl,'sample.dmp','DATA_PUMP_DIR',NULL,dbms_datapump.ku$_file_type_dump_file);
+  DBMS_DATAPUMP.ADD_FILE(v_hdnl,'sample_exp.log','DATA_PUMP_DIR',NULL,dbms_datapump.ku$_file_type_log_file);
+  DBMS_DATAPUMP.METADATA_FILTER(v_hdnl,'SCHEMA_EXPR','IN (''SCHEMA_1'')');
+  DBMS_DATAPUMP.START_JOB(v_hdnl);
+END;
+/
+-- (expdp equivalent: expdp user/pwd@src DIRECTORY=DATA_PUMP_DIR DUMPFILE=sample.dmp SCHEMAS=SCHEMA_1 PARALLEL=4)
+-- For a TDE source, export with ENCRYPTION_MODE=PASSWORD (TRANSPARENT mode is NOT supported by RDS).
+-- Each S3 object must be ≤ 5 TiB — use PARALLEL to split larger dumps into multiple files.
+```
+
+```sql
+-- 3. Upload dump to S3 (from source, if source is also RDS; else use `aws s3 cp` from the OS)
+SELECT rdsadmin.rdsadmin_s3_tasks.upload_to_s3(
+  p_bucket_name=>'amzn-s3-demo-bucket', p_directory_name=>'DATA_PUMP_DIR') AS task_id FROM dual;
+
+-- 4. On TARGET (as master): download dump from S3 into DATA_PUMP_DIR (async; returns a task id)
+SELECT rdsadmin.rdsadmin_s3_tasks.download_from_s3(
+  p_bucket_name=>'amzn-s3-demo-bucket', p_directory_name=>'DATA_PUMP_DIR') AS task_id FROM dual;
+-- confirm the file landed
+SELECT * FROM TABLE(rdsadmin.rds_file_util.listdir('DATA_PUMP_DIR')) ORDER BY mtime;
+```
+
+```sql
+-- 5. On TARGET (as master): import via DBMS_DATAPUMP. Add METADATA_REMAP for tablespace/schema
+--    remap; set TABLE_EXISTS_ACTION=>'REPLACE' to re-run.
+DECLARE v_hdnl NUMBER;
+BEGIN
+  v_hdnl := DBMS_DATAPUMP.OPEN(operation=>'IMPORT', job_mode=>'SCHEMA', job_name=>NULL);
+  DBMS_DATAPUMP.ADD_FILE(v_hdnl,'sample.dmp','DATA_PUMP_DIR',NULL,dbms_datapump.ku$_file_type_dump_file);
+  DBMS_DATAPUMP.ADD_FILE(v_hdnl,'sample_imp.log','DATA_PUMP_DIR',NULL,dbms_datapump.ku$_file_type_log_file);
+  DBMS_DATAPUMP.METADATA_FILTER(v_hdnl,'SCHEMA_EXPR','IN (''SCHEMA_1'')');
+  DBMS_DATAPUMP.START_JOB(v_hdnl);
+END;
+/
+```
+
+```bash
+# 5-alt. Or run impdp from a REMOTE Instant Client (bastion/EC2) against the RDS endpoint:
+impdp admin@//RDS-ENDPOINT:1521/DBNAME \
+  directory=DATA_PUMP_DIR dumpfile=sample.dmp logfile=sample_imp.log \
+  schemas=SCHEMA_1 table_exists_action=replace
+```
+
+```sql
+-- 6. Cleanup — dump files are NOT auto-purged and consume the same EBS volume as datafiles
+EXEC UTL_FILE.FREMOVE('DATA_PUMP_DIR','sample.dmp');
+```
+
+**Alternative transfer (no S3): `DBMS_FILE_TRANSFER` over a DB link** — create a DB link from source to the RDS endpoint, then `DBMS_FILE_TRANSFER.PUT_FILE(...)` to push `sample.dmp` into the target `DATA_PUMP_DIR`; import as in step 5. Requires VPC routing + security-group ingress between source and target.
+
+**Best practice:** transfer the dump → take a **DB snapshot** → test the import. If objects get invalidated, delete and recreate from the snapshot (the staged dump is included).
+
+**Transportable tablespaces (XTTS, very large EE DBs):** use the dedicated `rdsadmin.rdsadmin_transport_util` package (not the regular impdp path). EE-only, source ≥ 12c, Linux only, target release ≥ source, **no encrypted tablespaces**, cannot transport `SYSTEM`/`SYSAUX` or non-data objects (recreate PL/SQL/views/users/sequences via Data Pump metadata), and the instance must have no read replicas. S3 file limit 5 TiB (EFS recommended for larger). See [aws-official-migration-methods.md](aws-official-migration-methods.md).
+
+### If SQL Server Native Backup/Restore (SQL Server → RDS SQL Server, primary method)
+
+RDS SQL Server has **no OS access** and **no `RESTORE FROM DISK`** — you restore a `.bak` staged in **S3** via the `msdb.dbo.rds_*` procedures, enabled by the **`SQLSERVER_BACKUP_RESTORE`** option.
+
+**One-time setup:** create an S3 bucket in the **same Region**, an IAM role (trust `rds.amazonaws.com`, scoped with `aws:SourceArn` for the DB instance + option group), and add the option:
+```bash
+aws rds add-option-to-option-group --apply-immediately --option-group-name mybackupgroup \
+  --options "OptionName=SQLSERVER_BACKUP_RESTORE,OptionSettings=[{Name=IAM_ROLE_ARN,Value=arn:aws:iam::ACCT:role/rds-backup-restore-role}]"
+aws rds modify-db-instance --db-instance-identifier mydbinstance \
+  --option-group-name mybackupgroup --apply-immediately   # no restart required
+```
+The IAM permissions policy needs `s3:ListBucket`,`s3:GetBucketLocation` on the bucket and `s3:GetObject`,`s3:PutObject`,`s3:ListMultipartUploadParts`,`s3:AbortMultipartUpload`,`s3:GetObjectAttributes` on `bucket/*`; add `kms:DescribeKey`/`GenerateDataKey`/`Encrypt`/`Decrypt` on a **symmetric** key for encrypted backups.
+
+```sql
+-- 1. On SOURCE: take a native backup, then upload .bak to S3 (aws s3 cp from the source host)
+BACKUP DATABASE mydatabase TO DISK = 'D:\backups\mydb_full.bak' WITH INIT, FORMAT, COMPRESSION;
+```
+```bash
+aws s3 cp D:\backups\mydb_full.bak s3://my-bucket/sqlbackups/mydb_full.bak
+```
+```sql
+-- 2. On RDS: restore (single file → DB comes online; @with_norecovery defaults to 0 for FULL)
+exec msdb.dbo.rds_restore_database
+  @restore_db_name='mydatabase',
+  @s3_arn_to_restore_from='arn:aws:s3:::my-bucket/sqlbackups/mydb_full.bak';
+
+-- 3. Monitor (status refreshes ~every 5%; history kept 36 days)
+exec msdb.dbo.rds_task_status @db_name='mydatabase';
+-- cancel:  exec msdb.dbo.rds_cancel_task @task_id=<n>;   (cannot cancel FINISH_RESTORE)
+```
+
+**Multifile backup (large DBs, ≤10 files, parallel throughput):** the `*` is expanded to `1-of-N`, etc.:
+```sql
+exec msdb.dbo.rds_backup_database @source_db_name='mydatabase',
+  @s3_arn_to_backup_to='arn:aws:s3:::my-bucket/out/backup*.bak',
+  @number_of_files=4, @max_transfer_size=4194304, @buffer_count=10;
+-- restore by giving the common prefix + '*'
+exec msdb.dbo.rds_restore_database @restore_db_name='mydatabase',
+  @s3_arn_to_restore_from='arn:aws:s3:::my-bucket/out/backup*';
+```
+
+**Minimal-downtime sequence (FULL + DIFFERENTIAL + LOG)** — source must be in **FULL recovery model**. Restore the big backups ahead of time `WITH NORECOVERY`, apply the final log at cutover `WITH RECOVERY`:
+```sql
+exec msdb.dbo.rds_restore_database @restore_db_name='mydatabase',
+  @s3_arn_to_restore_from='arn:aws:s3:::my-bucket/mydb_full.bak', @type='FULL', @with_norecovery=1;
+exec msdb.dbo.rds_restore_database @restore_db_name='mydatabase',
+  @s3_arn_to_restore_from='arn:aws:s3:::my-bucket/mydb_diff.bak', @type='DIFFERENTIAL', @with_norecovery=1;
+exec msdb.dbo.rds_restore_log @restore_db_name='mydatabase',
+  @s3_arn_to_restore_from='arn:aws:s3:::my-bucket/mydb_log1.trn', @with_norecovery=1;
+-- final log at cutover brings the DB online (rds_restore_log defaults to NORECOVERY=1, so set 0)
+exec msdb.dbo.rds_restore_log @restore_db_name='mydatabase',
+  @s3_arn_to_restore_from='arn:aws:s3:::my-bucket/mydb_logN.trn', @with_norecovery=0;
+-- or, if the last task was left NORECOVERY:
+exec msdb.dbo.rds_finish_restore @db_name='mydatabase';
+```
+`rds_restore_log` supports `@stopat='2026-06-04 03:57:09'` for point-in-time. Drop a stuck restore: `exec msdb.dbo.rds_drop_database @db_name='mydatabase';`
+
+**Constraints:** S3 bucket same Region as instance; cannot restore over an existing DB name; 5 TB per file, native restore up to 64 TiB (Express 10 GB); up to 2 concurrent tasks; **cannot back up to a `.bak` from RDS for log shipping (no native log backups from RDS)**; a `.bak` from a *higher* engine version won't restore; FILESTREAM filegroups rejected; Multi-AZ native restore requires FULL recovery model; not supported with cross-Region read replicas; KMS must be symmetric; procedures can't run inside a transaction. **Logins, SQL Agent jobs, and linked servers are NOT in a user-DB `.bak`** — migrate them separately (§"SQL Server — Server-Level Objects" below).
+
+---
+
+## Schema Object Migration (If Method Doesn't Include Them)
+
+If you used DMS, binlog replication, or S3 import — schema objects must be migrated separately:
+
+```bash
+# MySQL: Export schema objects only (no data)
+mysqldump --routines --triggers --events --no-data --no-create-info \
+  -h $SOURCE -u admin -p your_db > schema_objects.sql
+
+# Remove DEFINER clauses (they break on Aurora)
+sed -i 's/DEFINER=[^*]*\*/\*/g' schema_objects.sql
+
+# Import to target
+mysql -h $TARGET -u admin -p your_db < schema_objects.sql
+```
+
+```bash
+# PostgreSQL: Functions, triggers, views, types
+pg_dump --schema-only --no-owner --no-privileges \
+  -h $SOURCE -U postgres your_db | \
+  grep -v 'COMMENT ON EXTENSION' > schema.sql
+
+psql -h $TARGET -U postgres -d your_db -f schema.sql
+```
+
+### Oracle — Objects NOT Carried by a Schema-Mode Data Pump
+
+Schema-mode Data Pump brings in-schema objects (procs, triggers, views, sequences). It does **not** bring SYS/SYSTEM-owned Scheduler jobs (intentionally excluded), nor will arbitrary directory objects / ACLs work as-is on RDS:
+- **Scheduler jobs**: recreate **app-owned** `DBMS_SCHEDULER` jobs on the target (migrate any legacy `DBMS_JOB` to `DBMS_SCHEDULER`). Never recreate SYS/SYSTEM-owned jobs.
+- **Network ACLs** (for `UTL_HTTP`/`UTL_SMTP`/`UTL_TCP`): re-grant with `DBMS_NETWORK_ACL_ADMIN` on the target and confirm VPC egress.
+- **Database links**: recreate; they need VPC routing + security-group rules and updated TNS descriptors.
+- **Directory objects / external tables / BFILE**: re-stage through RDS-managed directories (the master user lacks `CREATE ANY DIRECTORY`).
+
+### SQL Server — Server-Level Objects (logins, Agent jobs, linked servers)
+
+A user-DB `.bak` carries **database users** but not **server logins** → SQL-auth users are **orphaned** after restore (login SID mismatch). Fastest fix: recreate logins on RDS with the **same SID + HASHED password** so the orphan auto-resolves.
+
+```sql
+-- On SOURCE: generate CREATE LOGIN statements preserving hash + SID
+SELECT 'CREATE LOGIN ' + QUOTENAME(p.name) +
+  CASE WHEN p.type_desc='SQL_LOGIN'
+    THEN ' WITH PASSWORD = ' + CONVERT(NVARCHAR(MAX),l.password_hash,1) +
+         ' HASHED, SID = ' + CONVERT(NVARCHAR(MAX),p.sid,1) + ';'
+    ELSE ' FROM WINDOWS;' END
+FROM sys.server_principals p
+LEFT JOIN sys.sql_logins l ON p.principal_id=l.principal_id
+WHERE p.type_desc IN ('SQL_LOGIN','WINDOWS_LOGIN','WINDOWS_GROUP')
+  AND p.name NOT LIKE '##%##' AND p.name <> 'sa'
+  AND p.name NOT LIKE 'NT SERVICE%' AND p.name NOT LIKE 'NT AUTHORITY%';
+```
+```sql
+-- On RDS, after restore: if a user is still orphaned, relink (preferred over deprecated sp_change_users_login)
+USE [mydatabase];
+EXEC sp_change_users_login 'Report';     -- list orphans
+ALTER USER [appuser] WITH LOGIN = [appuser];
+```
+- **SQL Agent jobs** live in `msdb` (not importable) — script them out on the source and recreate (no CmdExec/PowerShell/replication steps, no email/alerts on RDS).
+- **Linked servers** are server-level — recreate manually (Oracle OLEDB has a dedicated RDS option).
+- **CLR**: `SAFE` assemblies only on ≤2016; not supported 2017+ — refactor.
+
+### TDE-Encrypted Source — Bringing the Certificate / Re-encrypting
+
+- **Oracle**: you **cannot import your own wallet**. Export with Data Pump `ENCRYPTION_MODE=PASSWORD`, import into a TDE-enabled target whose wallet **AWS generates** (`SELECT * FROM v$encryption_wallet;` to confirm). Create encrypted tablespaces normally: `CREATE TABLESPACE enc_ts ENCRYPTION USING 'AES256' DEFAULT STORAGE(ENCRYPT);`. The `TDE` option is permanent — to remove it you must export to a non-TDE instance.
+- **SQL Server**: bring the **source TDE certificate** in first via `rds_restore_tde_certificate` (cert name must start with `UserTDECertificate_`). On the source, `BACKUP CERTIFICATE ... WITH PRIVATE KEY`, where the private-key password is the **plaintext** of a KMS data key (`aws kms generate-data-key --key-spec AES_256`); upload `.cer`/`.pvk` to S3 and tag the `.pvk` object with `x-amz-meta-rds-tde-pwd` = the KMS `CiphertextBlob`:
+  ```sql
+  EXECUTE msdb.dbo.rds_restore_tde_certificate
+    @certificate_name='UserTDECertificate_mycert',
+    @certificate_file_s3_arn='arn:aws:s3:::cert-bucket/tde-cert.cer',
+    @private_key_file_s3_arn='arn:aws:s3:::cert-bucket/tde-key.pvk',
+    @kms_password_key_arn='arn:aws:kms:us-west-2:ACCT:key/<key-id>';
+  ```
+  Then `rds_restore_database` the TDE `.bak`; RDS **auto-rekeys** the restored DB to an RDS-managed `RDSTDECertificate` before it becomes available. Constraints: both `SQLSERVER_BACKUP_RESTORE` + `TDE` options required; **TDE cert restore not supported on Multi-AZ** (do it Single-AZ, then convert); max 10 user certs; no cross-account KMS keys.
+
+---
+
+## Migration Rehearsal (STRONGLY Recommended Before Production)
+
+> **If the customer declines a clone rehearsal** (common for small DBs — "too much
+> cost/time"): do not silently skip. (1) State plainly what risk moves into the production
+> window — untested cutover mechanics, unmeasured time budget. (2) Get the waiver recorded
+> in `migration-plan.md`. (3) Recover what rehearsal value you can without a clone:
+> component-test every freeze-window command against the REAL target (syntax differs
+> across engine versions), pre-stage the cutover scripts on-host (see cutover-procedures.md
+> §"ONE Pre-Staged Script per Host"), and treat the forward seed+catch-up run as your
+> timing measurement. The canonical failure this prevents: an untested
+> `SHOW BINARY LOG STATUS` (MySQL 8.4 syntax) against Aurora 8.0, discovered mid-freeze,
+> turning a 40-second window into a 5-minute one.
+
+Before executing against production, perform a full dry-run:
+
+1. **Create a source clone**: Snapshot the source EC2, launch a clone in same VPC.
+2. **Run the full migration against the clone** (all phases).
+3. **Measure actual time**: Record duration of each phase.
+4. **Validate cutover procedure**: Practice end-to-end.
+5. **Verify rollback**: Test the rollback procedure works.
+6. **Destroy the clone**: Delete all rehearsal resources.
+
+This de-risks production by: confirming time estimates, catching permission/network/compatibility issues, giving team confidence, and providing a realistic timeline for stakeholders.

--- a/db-migration-agent-skill/shared/reference/heterogeneous-migration.md
+++ b/db-migration-agent-skill/shared/reference/heterogeneous-migration.md
@@ -1,0 +1,160 @@
+# All-Engine & Heterogeneous Migration Reference
+
+> **Scope** — every engine RDS/Aurora supports; **heterogeneous migrations** (Oracle/SQL Server → Aurora, engine family changes); and the **Korean-market source engines** (Tibero, CUBRID, Altibase) that have **no native AWS migration tooling**. For schema/code conversion, prefer chaining the official `dms-schema-conversion` skill ([mcp-and-tooling.md](mcp-and-tooling.md) §Chaining) and use this document for the decision framing, target selection, and the manual-conversion long tail.
+
+> **Companion documents**: [rds-aurora-limitations.md](rds-aurora-limitations.md), [aws-official-migration-methods.md](aws-official-migration-methods.md), [third-party-db-security.md](third-party-db-security.md), [regulatory-compliance.md](regulatory-compliance.md).
+
+---
+
+## 1. RDS / Aurora Engine Coverage
+
+**Amazon RDS** supports **8 engines** (incl. Aurora):
+
+| Engine | Notes |
+|--------|-------|
+| **PostgreSQL** | Versions ~13–17 GA; 11–12 via Extended Support. |
+| **MySQL** | 5.7 / 8.0+ (version & instance-class dependent). |
+| **MariaDB** | 10.x / 11.x. |
+| **SQL Server** | Express / Web / Standard / Enterprise (License Included or BYOM). |
+| **Oracle** | SE2 (LI or BYOL); EE (BYOL only). |
+| **Db2** | Most recent addition to the RDS family. |
+| **Aurora MySQL-Compatible** | ~5× MySQL throughput, storage to 128 TiB (verify current limit), up to 15 replicas, Global Database. |
+| **Aurora PostgreSQL-Compatible** | ~3× PostgreSQL throughput; supports **Babelfish** (T-SQL/TDS). |
+
+---
+
+## 2. Recommended Migration Target per Source Engine
+
+| Source | Recommended AWS target | Path / tooling |
+|--------|------------------------|----------------|
+| **Oracle** | Aurora PostgreSQL (cost / lock-in exit) **or** RDS for Oracle (lift-and-shift) | Heterogeneous: SCT or DMS Schema Conversion + DMS (CDC). Homogeneous: DMS or Data Pump/RMAN to RDS Oracle |
+| **MS SQL Server** | Aurora PostgreSQL **via Babelfish** (minimal app change) **or** RDS for SQL Server | Babelfish + DMS; or SCT/DMS Schema Conversion + DMS |
+| **MySQL** | Aurora MySQL or RDS for MySQL | Homogeneous — native dump/restore, XtraBackup+S3, snapshot, or DMS |
+| **MariaDB** | RDS for MariaDB or Aurora MySQL | Homogeneous (MariaDB treated as MySQL-compatible by DMS) |
+| **PostgreSQL** | Aurora PostgreSQL or RDS for PostgreSQL | Native pg_dump/restore, logical replication, snapshot/RR import, or DMS |
+| **Tibero** (TmaxData) | **Aurora PostgreSQL** (or RDS Oracle if staying Oracle-compatible) | **No native DMS/SCT support — see §5** |
+| **CUBRID** (Korean OSS) | Aurora MySQL or Aurora PostgreSQL | **No native connector — JDBC extraction — see §5** |
+| **Altibase** (Korean in-memory/hybrid) | Aurora PostgreSQL / Aurora MySQL | **No native connector — JDBC/custom — see §5** |
+
+> The cost-driven re-platform thesis: AWS positions **Aurora PostgreSQL/MySQL** as the open-source target that **removes commercial Oracle/SQL Server licensing entirely** — the primary economic driver for heterogeneous migration in Korea.
+
+---
+
+## 3. AWS Migration Tooling
+
+### 3.1 AWS DMS (Database Migration Service)
+
+- **Homogeneous** (Oracle→Oracle) and **heterogeneous** (Oracle→Aurora) migrations; keeps source live; **CDC** for continuous replication; Multi-AZ.
+- **Sources** include Oracle (10.2–19c), SQL Server (2008–2022, not Express), MySQL (5.5–8.4), MariaDB (10.x–11.4), PostgreSQL (9.4–18.x), MongoDB, SAP ASE, Db2 LUW & z/OS, plus Azure/Google/OCI managed DBs.
+- **Targets** include all RDS engines, Aurora MySQL/PostgreSQL (incl. Serverless v2 and Aurora PostgreSQL Limitless), Redshift, S3, DynamoDB, OpenSearch, Kafka/MSK, Neptune, DocumentDB, and **Babelfish for Aurora PostgreSQL**.
+- **DMS Serverless** auto-provisions/scales replication capacity — worth offering when you don't want to size a replication instance.
+- ⚠️ **DMS migrates data, not schema objects** — stored procedures, triggers, views, events, sequences, and grants are **not** carried by DMS. Convert schema separately (SCT / DMS Schema Conversion / native dump).
+
+### 3.2 AWS SCT (Schema Conversion Tool — desktop)
+
+Converts schema + code objects across a broad matrix:
+- **Oracle (10.1+) →** Aurora MySQL/PostgreSQL, MariaDB, MySQL, PostgreSQL.
+- **SQL Server (2008 R2–2022) →** Aurora MySQL/PostgreSQL, Babelfish (assessment report), MariaDB, MySQL, PostgreSQL.
+- Also converts **data-warehouse** schemas, **application SQL** (C++/C#/Java), **ETL** (SSIS→Glue, Teradata BTEQ), and **NoSQL** (Cassandra→DynamoDB).
+- Produces an **assessment report** + an **extension pack** (Lambda/Python) to emulate features that can't convert directly.
+
+### 3.3 DMS Schema Conversion (console/managed — "web SCT")
+
+- Narrower scope than SCT (no data-warehouse, big-data, application-SQL, or ETL conversion — use SCT for those).
+- Heterogeneous **Oracle / SQL Server → MySQL / PostgreSQL**; homogeneous MySQL/PostgreSQL.
+- Targets: Aurora MySQL 8.0.32, Aurora PostgreSQL 14–17, RDS MySQL/PostgreSQL, RDS Db2.
+- Includes **generative-AI-assisted conversion**. Converts tables, views, stored procedures, functions, data types, synonyms; flags unconvertible objects for manual work.
+- **When to use which**: SCT for the broad/complex jobs (DW, app code, ETL); DMS Schema Conversion for straightforward Oracle/SQL Server→PostgreSQL/MySQL schema work inside the console.
+
+### 3.4 Babelfish for Aurora PostgreSQL
+
+- Built-in Aurora PostgreSQL capability: accepts **SQL Server client connections over the TDS wire protocol** and understands **T-SQL** → SQL Server apps migrate with minimal code change.
+- T-SQL on port 1433, PL/pgSQL on 5432; TDS 7.1–7.4; requires **Aurora PostgreSQL 13+**; no extra cost.
+- **When to use**: migrating SQL Server when you want to **drop the SQL Server license** and keep most T-SQL/app code.
+- ⚠️ **Caveats**: not 100% T-SQL coverage (gaps close each release); differences in schema names, permissions, collations, transactional semantics; backup is pg_dump/restore-based. **Run an SCT/DMS Schema Conversion Babelfish assessment report first.**
+
+---
+
+## 4. Oracle → Aurora PostgreSQL — Specific Challenges
+
+The hard part of heterogeneous migration is **code**, not data. Budget for refactoring:
+
+| Area | Oracle | Aurora PostgreSQL | Action |
+|------|--------|-------------------|--------|
+| Procedural code | PL/SQL | PL/pgSQL | Different variable decl, cursors, exception model |
+| **Packages** | `CREATE PACKAGE` | **No direct equivalent** | Refactor into schemas + functions |
+| Sequences / identity | `CREATE SEQUENCE` | `SERIAL` / `GENERATED AS IDENTITY` | Ownership & permission semantics differ |
+| **Hierarchical queries** | `CONNECT BY … START WITH` | **No equivalent** | Rewrite as `WITH RECURSIVE` CTE |
+| Functions | `DECODE`, `NVL`, `ROWNUM` | — | Replace with `CASE`, `COALESCE`, window/`LIMIT` |
+| Bitmap indexes | supported | **unsupported** | Redesign indexing |
+| Data types | `NUMBER`, `VARCHAR2`, `DATE`(w/ time), `CLOB`/`BLOB`, `CHAR` | `NUMERIC`, `VARCHAR`, `TIMESTAMP`/`DATE`, `TEXT`/`BYTEA` | Be explicit; CHAR padding differs |
+| Materialized views / partitioning | Oracle semantics | PostgreSQL semantics | Refresh & partition differences |
+
+**Two-step process**: (1) convert schema/code (SCT or DMS Schema Conversion + manual fix-ups for flagged objects), then (2) move data (DMS full-load + CDC with automatic data-type conversion).
+
+---
+
+## 5. Korean Source Engines With No Native AWS Tooling ⚠️
+
+> **This is the single most important gap for a Korean-market playbook.** **Tibero, CUBRID, and Altibase are absent from both the AWS DMS supported-source list and the AWS SCT source list.** There is **no AWS-published migration guide** for any of them. Plan for a **PoC** and custom/JDBC data movement.
+
+### 5.1 Tibero (TmaxData / TmaxSoft)
+
+- Commercial RDBMS **engineered for bidirectional Oracle compatibility** (SQL, PL/SQL, data types, optimizer hints map closely to Oracle).
+- **Recommended target**: **Aurora PostgreSQL** (open-source exit) or RDS for Oracle (if staying Oracle-compatible).
+- **Practical path** (no native connector): because Tibero is Oracle-compatible, treat its schema/PL-SQL **like Oracle** for **manual or SCT-assisted conversion** to Aurora PostgreSQL (point SCT at the Oracle-compatible DDL/PL-SQL where extractable). Move **data** via **JDBC-based bulk extract → S3/CSV → load**, or custom ETL (Glue / scripts). A Tibero JDBC driver against the Oracle/generic DMS endpoint is **not officially supported**.
+- **[Validate in PoC]** — no AWS-published Tibero guide exists.
+
+### 5.2 CUBRID (Korean open-source DB)
+
+- **Recommended target**: Aurora MySQL or Aurora PostgreSQL (CUBRID is MySQL-like in many respects).
+- **Path**: **JDBC extraction → S3/CSV → load into Aurora**; schema converted manually. **[Validate in PoC]**
+
+### 5.3 Altibase (Korean in-memory / hybrid DB)
+
+- **Recommended target**: Aurora PostgreSQL or Aurora MySQL depending on the app's SQL dialect (Altibase has Oracle-like and ANSI SQL features).
+- **Path**: **JDBC/custom extraction → S3 → load**; manual schema conversion. **[Validate in PoC]**
+
+> **No silent caps**: when a plan involves Tibero/CUBRID/Altibase, **explicitly tell the customer** there is no native AWS tooling, a PoC is required, and the schema/code conversion is largely manual. Do not imply DMS/SCT will "just work."
+
+---
+
+## 6. License Implications
+
+| Engine | Model | Editions |
+|--------|-------|----------|
+| **Oracle on RDS** | **License Included (LI)** — AWS bundles Oracle | **SE2 only** |
+| | **BYOL** — your existing licenses | SE2 **and** Enterprise Edition (requires active Software Update License & Support) |
+| **SQL Server on RDS** | **License Included (LI)** | Enterprise / Standard / Web / Express |
+| | **BYOM** (License Mobility + Software Assurance) | Enterprise / Standard / Developer |
+| **Aurora / open-source** | No commercial DB license | The cost-driven migration target |
+
+---
+
+## 7. Heterogeneous Migration — Task Additions for the Plan
+
+When the move is heterogeneous (Oracle/SQL Server/Tibero → Aurora), the standard DB task list gains these phases:
+
+- [ ] **Schema assessment** — run SCT / DMS Schema Conversion assessment report; quantify auto-convert % vs. manual objects.
+- [ ] **Code conversion** — refactor packages, hierarchical queries, proprietary functions; convert PL/SQL → PL/pgSQL (or assess Babelfish T-SQL coverage for SQL Server).
+- [ ] **Babelfish decision** (SQL Server only) — assessment report → Babelfish vs. full PostgreSQL refactor vs. RDS SQL Server.
+- [ ] **Data type mapping validation** — verify NUMBER/DATE/CLOB conversions don't lose precision or truncate.
+- [ ] **Application SQL remediation** — embedded SQL in the app that uses source-specific
+  dialect. This skill does NOT edit the customer's application: it produces
+  **`app-remediation-findings.md`** — a machine-readable findings list (file:line where
+  detectable, offending construct, target-dialect replacement, severity) — as a **handoff
+  artifact for a separate app-side engagement**. That engagement runs in the customer's
+  application repo with THEIR review and CI tests, and can itself be agent-assisted (the
+  same coding agent, pointed at their repo, consuming this findings list). Track it as a
+  critical-path dependency in migration-plan.md: data can be ready long before the app is.
+- [ ] **PoC** (Tibero/CUBRID/Altibase) — prove the JDBC extract/load path and conversion before committing the cutover plan.
+- [ ] **Dual-read validation** — compare query results (not just row counts) between source and target for converted code.
+- [ ] **License decommission** — confirm Oracle/SQL Server license retirement and cost savings post-cutover.
+
+---
+
+## 8. Honesty / Confidence Notes
+
+- Engine support, DMS/SCT source-target matrices, Babelfish, and license models are grounded in current AWS documentation (research as of **2026-06**).
+- **Tibero/CUBRID/Altibase absence from DMS/SCT is verified**; the recommended paths for them are **architecture-grounded inference** requiring a PoC.
+- Re-verify engine versions and DMS Schema Conversion target versions before publishing — they move frequently.

--- a/db-migration-agent-skill/shared/reference/mcp-and-tooling.md
+++ b/db-migration-agent-skill/shared/reference/mcp-and-tooling.md
@@ -1,0 +1,96 @@
+# MCP Servers & AWS Agent Toolkit Integration
+
+> How this skill uses MCP tools vs the AWS CLI, which servers to recommend, and how to
+> chain the official AWS skills. Convention follows the Agent Toolkit for AWS:
+> **MCP-first for volatile facts and sandboxed execution; AWS CLI fallback always works.**
+> Verified against live AWS docs/GitHub as of 2026-07. Re-verify before publishing —
+> this area moves fast.
+
+## The rule (tiered, based on live test evidence)
+
+- **Homogeneous engagements: the Agent Toolkit is recommended, not required.** Every
+  instruction in this skill is executable with the plain AWS CLI + a DB client, and the
+  full workflow works end-to-end without any MCP connected.
+  When the toolkit IS connected, prefer it for the stated purposes (volatile-fact
+  verification, `aws___call_aws` audited execution, DB queries without local clients).
+  When absent, record **"MCP: not connected — CLI fallback"** in the Phase 0 preflight
+  table plus the one real degradation: engine-version/regional facts were verified by
+  CLI queries rather than live docs, so re-check anything version-sensitive against the
+  console at GATE 2.
+- **Heterogeneous engagements: the Agent Toolkit is REQUIRED.** Schema/code conversion
+  chains to AWS's official `dms-schema-conversion` skill via `retrieve_skill`, and
+  assessing conversion coverage without it means hand-driving DMS Schema Conversion
+  through the CLI — slower and error-prone enough that the engagement should not
+  proceed on the fallback. If the customer environment can't connect the toolkit,
+  treat that as a Phase 0 blocker for the heterogeneous path (fix connectivity, or run
+  the conversion workstream in an environment that has it).
+
+## Primary: the managed AWS MCP Server (Agent Toolkit for AWS)
+
+The official successor to the awslabs local servers. Remote, IAM-gated, free.
+Repo: `github.com/aws/agent-toolkit-for-aws` · Docs: `docs.aws.amazon.com/agent-toolkit/`
+
+**Install (Claude Code):**
+```
+/plugin install aws-core@claude-plugins-official
+```
+or manual `.mcp.json` (SigV4 via proxy; requires AWS CLI ≥ 2.32, `aws login`, uv):
+```json
+{"mcpServers": {"aws-mcp": {"command": "uvx", "args": [
+  "mcp-proxy-for-aws@latest", "https://aws-mcp.us-east-1.api.aws/mcp",
+  "--metadata", "AWS_REGION=<operating-region>"]}}}
+```
+
+**Tools this skill uses:**
+
+| When | Tool | Why |
+|------|------|-----|
+| Verify engine-version availability, DMS source/target support, regional availability | `aws___get_regional_availability`, `aws___search_documentation` | These facts churn; never answer from memory |
+| Read exact RDS/DMS API or procedure detail | `aws___read_documentation` | e.g. current `rds_restore_database` constraints |
+| Run any AWS API call (DMS, RDS, EC2, Route 53, Secrets Manager) | `aws___call_aws` | Audited alternative to `aws` CLI; adds `aws:CalledViaAWSMCP` condition key |
+| Long-running operations (restore-db-cluster-from-s3, DMS task) | `aws___get_tasks` | Poll instead of blocking |
+| Load official AWS skills at runtime | `aws___retrieve_skill` | See "Chaining official skills" below |
+
+## Chaining official AWS skills (do NOT duplicate them)
+
+| Situation | Delegate to | How |
+|-----------|-------------|-----|
+| **Heterogeneous** schema conversion (Oracle/SQL Server → Aurora/PG/MySQL) | **`dms-schema-conversion`** skill (Agent Toolkit, `skills/specialized-skills/migration-and-modernization-skills/`) | `Load "dms-schema-conversion" skill using the retrieve_skill tool.` — covers DMS SC projects, data providers, metadata import/conversion, action items. Then return here for data movement + cutover. |
+| Target-engine operational questions post-migration | `amazon-aurora-mysql`, `amazon-aurora-postgresql`, `rds-oracle`, `rds-sqlserver`, `rds-oss`, `rds-db2` skills | Same `retrieve_skill` mechanism, or the `aws-database` router skill in the `aws-core` plugin |
+
+This skill's own ground is what none of those cover: end-to-end **data migration
+orchestration** — assessment, method selection, DMS replication config, native paths,
+client discovery, cutover, reverse replication, rollback.
+
+## Companion local MCP servers (optional, per engagement)
+
+All are `uvx awslabs.<name>@latest`, env `AWS_PROFILE`/`AWS_REGION`. Credentials via
+Secrets Manager ARN — consistent with this skill's no-passwords-in-argv rule.
+
+| Server | Use in this skill | Notes |
+|--------|-------------------|-------|
+| `awslabs.mysql-mcp-server` | Query source EC2/on-prem MySQL/MariaDB (assessment SQL) and target Aurora MySQL (validation SQL) without a local `mysql` client | `mysqlwire` for self-hosted sources; read-only by default — keep it that way for the source |
+| `awslabs.postgres-mcp-server` | Same for PostgreSQL / Aurora PostgreSQL | `pgwire` / `pgwire_iam` / `rdsapi` connection methods |
+| `awslabs.oracle-mcp-server` | Source/target Oracle inventory queries | Read-only via `SET TRANSACTION READ ONLY` |
+| `awslabs.mssql-mcp-server` | Source/target SQL Server inventory queries | Secrets Manager auth |
+| `awslabs.cloudwatch-mcp-server` | Watch DMS task metrics (`CDCLatencySource/Target`), alarms, log-insights during Phases 6–8 | `get_metric_data`, `get_active_alarms`, `execute_log_insights_query` |
+| `awslabs.aws-pricing-mcp-server` | Cost estimate at GATE 2 (RDS/Aurora instance, storage, DMS instance, data transfer) | `get_pricing`, `generate_cost_report`; IAM `pricing:*` only |
+
+## ⚠️ Known trap
+
+**Do not install `awslabs.aws-dms-mcp-server` from PyPI.** As of 2026-07 that package
+name is squatted by a third party ("security research") — it is **not AWS**. There is no
+official DMS MCP server; drive DMS through `aws___call_aws` or the AWS CLI.
+
+Also superseded (don't recommend for new setups): `awslabs.aws-api-mcp-server` (replaced
+by the managed AWS MCP Server; AWS docs advise removing it to avoid tool conflicts) and
+`awslabs.cost-explorer-mcp-server` (folded into `awslabs.billing-cost-management-mcp-server`).
+
+## Fallback matrix (no MCP connected)
+
+| Need | Fallback |
+|------|----------|
+| AWS API calls | `aws` CLI (the skill's snippets are already CLI-form) |
+| Source DB queries with no local client | SSM Send-Command / port-forwarding paths in [source-assessment.md](source-assessment.md) |
+| Doc verification | Ask the user to confirm against the console, and mark the assumption in `migration-plan.md` |
+| Pricing | AWS Pricing Calculator link with the parameters filled into `migration-plan.md` |

--- a/db-migration-agent-skill/shared/reference/method-selection.md
+++ b/db-migration-agent-skill/shared/reference/method-selection.md
@@ -1,0 +1,147 @@
+# Migration Method Selection
+
+> Read this during **Phase 3 (Select Method)**. The method is a decision the user must
+> make or approve — present options with trade-offs, never silently pick one.
+> Full per-method procedures: [execution-runbooks.md](execution-runbooks.md) and
+> [aws-official-migration-methods.md](aws-official-migration-methods.md).
+
+## Method Selection Procedure
+
+**This is a decision the user must make (or approve).** Present the options with trade-offs.
+
+> The decision inputs below were already collected during Phase 1 discovery
+> (`migration-plan.md` §Phase 1) — **do not re-ask what is already answered**; use this
+> list only to spot gaps that block a matrix row from resolving.
+
+### Decision Input — Ask the User
+
+1. **Homogeneous or heterogeneous?** Same engine family (MySQL→MySQL/Aurora MySQL, PostgreSQL→PostgreSQL/Aurora PG, MariaDB→MariaDB, **Oracle→RDS Oracle, SQL Server→RDS SQL Server**) = **homogeneous**, stay in this skill (homogeneous path). Engine family *changes* (Oracle/SQL Server/Tibero/CUBRID → Aurora/PostgreSQL/MySQL, MySQL→PostgreSQL) = **heterogeneous**, go to [heterogeneous-migration.md](heterogeneous-migration.md) first (schema/code conversion), then return for cutover.
+2. **What is your source?** EC2 MySQL / EC2 MariaDB / EC2 PostgreSQL / EC2/on-prem Oracle / EC2/on-prem SQL Server / RDS MySQL / RDS MariaDB / RDS PostgreSQL / On-premises / Other cloud (Azure DB, Cloud SQL)
+3. **What is your target?** Aurora MySQL / Aurora PostgreSQL / RDS MySQL / RDS MariaDB / RDS PostgreSQL / **RDS Oracle** / **RDS SQL Server**
+4. **Downtime tolerance?** Zero / Seconds / Minutes / Hours (maintenance window)
+5. **Database size?** < 10 GB / 10-100 GB / 100 GB - 1 TB / > 1 TB
+6. **Network bandwidth (source → AWS)?** Same-VPC/region / Direct Connect (state Gbps) / VPN (state Mbps) / internet egress (state Mbps) — needed for the throughput check in source-assessment.md §Throughput Estimation.
+7. **Do you need stored procedures, triggers, views migrated?** Yes / No / Don't know
+8. **Migrating more than one database?** If yes, see "Multi-database scenarios" below.
+9. **Do you have a preferred method?** (User may already know what they want)
+10. **Number of databases on the source host?** (If >1, each migrates independently. Flag schema name collisions.)
+11. **Can the application code be modified?** (Gates: app-side encryption, connection-string change vs Secrets Manager, dual-read capability)
+12. **RPO (Recovery Point Objective)?** (Acceptable data loss if rollback needed. Zero RPO requires reverse replication.)
+13. **Downstream CDC consumers?** (Debezium/Kafka, BI replicas, ETL jobs reading binlog — these break at cutover and need re-pointing.)
+14. **Encryption requirement at creation time?** (KMS key type: AWS-managed vs CMK. Cannot change after cluster creation.)
+15. **Cross-region or cross-account?** (Routes to different networking/KMS/DMS setup.)
+
+### Method Decision Matrix
+
+> **Homogeneous only.** This matrix is for same-engine-family migrations, including **Oracle → RDS
+> Oracle** (rows 13–15) and **SQL Server → RDS SQL Server** (rows 16–18). If the engine family
+> *changes* (Oracle/SQL Server/Tibero/CUBRID → Aurora/PostgreSQL/MySQL, or MySQL ↔ PostgreSQL), stop
+> and use [heterogeneous-migration.md](heterogeneous-migration.md) — you need
+> schema/code conversion (SCT / DMS Schema Conversion / Babelfish) before any data move.
+>
+> **Deterministic read order.** Rows are evaluated **top to bottom; take the FIRST row whose
+> Source + Target + Size + Downtime + Bandwidth all match.** Conditions are mutually exclusive
+> within a source, so exactly one row applies. "Bulk transfer fits window?" refers to the
+> Phase 2 throughput estimate (`estimated_hours` vs transfer window).
+
+| # | Source | Target | Size | Downtime tolerance | Bulk transfer fits window? | **Recommended Method** | Why |
+|---|--------|--------|------|--------------------|----------------------------|------------------------|-----|
+| 1 | RDS MySQL | Aurora MySQL | Any | < 1 min | n/a (same region) | **Aurora Read Replica promotion** | Built-in, seconds of downtime, migrates everything |
+| 2 | RDS MySQL **or** RDS MariaDB | RDS MySQL / RDS MariaDB / Aurora MySQL | Any | < 1 min | n/a | **Blue/Green Deployment** | Managed switchover w/ guardrails (MySQL↔Aurora MySQL cross-engine supported) |
+| 3 | RDS PostgreSQL | Aurora PostgreSQL | Any | < 1 min | n/a | **Aurora Read Replica promotion** | Built-in |
+| 4 | EC2/on-prem MySQL or MariaDB | Aurora MySQL / RDS MySQL / RDS MariaDB | < 10 GB | Yes (< 1 hr) | Yes | **mysqldump** (`--routines --triggers --events`) | Simplest, migrates ALL objects |
+| 5 | EC2/on-prem MySQL or MariaDB | Aurora MySQL / RDS MySQL / RDS MariaDB | 10 GB – 1 TB | Yes (hours) | Yes | **Percona XtraBackup + S3** | 3–7× faster than DMS, physical copy incl. all objects |
+| 6 | EC2/on-prem MySQL or MariaDB | Aurora MySQL / RDS MySQL / RDS MariaDB | > 1 TB | Minimal (minutes) | Yes | **XtraBackup + S3 seed → binlog/DMS CDC catch-up** | Fast physical bulk, then drain delta; cutover = final drain |
+| 7 | EC2/on-prem MySQL or MariaDB | Aurora MySQL / RDS MySQL / RDS MariaDB | Any | No (zero/seconds) | Yes | **DMS Full Load + CDC** | Only near-zero-downtime path from EC2/on-prem (see schema-objects note) |
+| 8 | On-prem MySQL/MariaDB/PostgreSQL | Aurora / RDS (same family) | > 1 TB | Any | **No** (bandwidth-bound) | **Snow Family seed + DMS CDC** (or DataSync for 100 GB–1 TB) | Wire can't carry it in time — see Offline-Seed Branch |
+| 9 | EC2/on-prem PostgreSQL | Aurora PostgreSQL / RDS PostgreSQL | < 10 GB | Yes | Yes | **pg_dump / pg_restore** (`-Fd -j`) | Complete (all objects), simple, parallel |
+| 10 | EC2/on-prem PostgreSQL | Aurora PostgreSQL / RDS PostgreSQL | 10 GB – 1 TB | Yes (hours) | Yes | **pg_dump/restore (parallel)** | No physical-backup S3 path for PG; parallel dump is the bulk tool |
+| 11 | EC2/on-prem PostgreSQL | Aurora PostgreSQL / RDS PostgreSQL | Any | No (zero/seconds) | Yes | **Native logical replication** (preferred) or **DMS CDC** | PG-native handles more DDL; DMS simpler to operate |
+| 12 | Other cloud (Azure DB for MySQL/PostgreSQL, Cloud SQL) | Aurora / RDS (same family) | Any | No (near-zero) | per estimate | **DMS Full Load + CDC** | No native cross-cloud replica; DMS connects over public/peered endpoint |
+| 13 | EC2/on-prem **Oracle** | **RDS Oracle** | < 1 TB | Yes (hours) | Yes | **Oracle Data Pump** (schema/table mode, via S3 integration) | AWS-recommended logical method; migrates schema + data. No FULL mode. |
+| 14 | EC2/on-prem **Oracle** (EE) | **RDS Oracle** (EE) | > 1 TB | Minimal (minutes) | Yes | **Transportable tablespaces (XTTS via RMAN)** → optional DMS CDC catch-up | Physical, fastest for very large EE DBs; EE-only, no encrypted tablespaces, source not 11g. |
+| 15 | EC2/on-prem **Oracle** | **RDS Oracle** | Any | No (zero/near-zero) | Yes | **Data Pump bulk load → AWS DMS CDC from recorded SCN** (or GoldenGate) | Only near-zero-downtime path; Data Pump seeds, DMS/GoldenGate drains delta. |
+| 16 | EC2/on-prem **SQL Server** | **RDS SQL Server** | Any | Yes (hours) | Yes | **Native backup/restore** (.bak via S3, `rds_restore_database`) | AWS-recommended lift-and-shift; migrates the user DB. Logins/jobs separate (execution-runbooks.md §schema objects). For tiny DBs (< ~5 GB) a scripted schema+`bcp` copy is an acceptable substitute when the S3/option-group setup outweighs it — but .bak is the default: it preserves everything in-DB (permissions, defaults, computed cols) with no per-object scripting risk. |
+| 17 | EC2/on-prem **SQL Server** | **RDS SQL Server** | > 1 TB | Minimal (minutes) | Yes | **Native FULL + DIFFERENTIAL + LOG** (restore WITH NORECOVERY, final log WITH RECOVERY at cutover) | Shrinks cutover to tail-log restore. Source must be FULL recovery model. |
+| 18 | EC2/on-prem **SQL Server** | **RDS SQL Server** | Any | No (zero/near-zero) | Yes | **AWS DMS Full Load + CDC** | Near-zero downtime; DMS moves data only — migrate logins/jobs/perms separately. |
+
+**Notes on overlap resolution:**
+- Rows 13–15 (Oracle): prefer **Data Pump** (row 13) for the common downtime-OK case; **XTTS** (row 14) only when EE + very large + no encrypted tablespaces + source ≥ 12c; **DMS/GoldenGate CDC** (row 15) when downtime must be near-zero. RMAN whole-DB physical restore is **NOT** supported into managed RDS Oracle (EC2/RDS Custom only).
+- Rows 16–18 (SQL Server): prefer **native backup/restore** (row 16); use **full+diff+log** (row 17) to minimize the cutover window; **DMS** (row 18) only for near-zero downtime. Log Shipping, Replication, and `RESTORE FROM DISK` are not available on RDS.
+- Rows 1 vs 2 for RDS MySQL → Aurora MySQL: prefer **Read Replica promotion** (row 1) for the
+  lowest downtime; choose **Blue/Green** (row 2) when you want staged validation + one-command
+  switchover, or when also doing a version upgrade.
+- Snapshot migration (RDS-source, minutes of downtime) is a fallback only when Read Replica /
+  Blue/Green are unavailable for the engine version — not a first choice, so it's omitted from the
+  primary tree.
+- The old "RDS Console Auto-Migrate / Any-Any" catch-all has been **removed**: it is just a console
+  wrapper around DMS and applied to scenarios it doesn't fit (on-prem, >1 TB, heterogeneous). Use the
+  specific row above; if you want the console UX, that maps to row 7/12 (DMS) behind the scenes.
+
+### Binlog State Gate (MySQL/MariaDB — check BEFORE committing to a method)
+
+Every near-zero-downtime path (DMS CDC, binlog replication, reverse replication for lossless rollback) **requires `log_bin=ON` with `binlog_format=ROW`** on the source. Carry the Phase 2 `SHOW VARIABLES LIKE 'log_bin'` result *directly* into method selection — do not assume CDC is available:
+
+| Source `log_bin` | DB size | Recommendation |
+|------------------|---------|----------------|
+| **ON** (`binlog_format=ROW`) | Any | CDC methods available — matrix rows 6–8 (XtraBackup+CDC, DMS) are on the table. |
+| **OFF** | Small (rough guide: **< ~1–2 GB**, fits a brief maintenance window per the Phase 2 throughput estimate) | **Prefer a brief dump cutover** (mysqldump → import → repoint app). Enabling binlog requires a **source restart = downtime anyway**; for a tiny DB the one-shot dump cutover causes *less total disruption* than "restart to enable binlog, then stand up DMS." |
+| **OFF** | Large | You must **enable binlog first** (`log_bin=ON`, `binlog_format=ROW`, adequate `binlog retention`) — and **acknowledge the restart cost** with the user — before any CDC method. There is no zero-downtime path while binlog is off. |
+
+> **The contradiction to surface explicitly:** "zero-downtime" and `log_bin=OFF` are mutually exclusive until you take the restart to enable binlog. State this trade-off to the user; for small DBs the honest answer is often a 1–2 minute dump cutover, not a CDC project. This also means **reverse replication may be impossible** — see cutover-procedures.md §"When Reverse Replication is NOT Possible."
+
+### Multi-Database Scenarios
+
+When consolidating or moving more than one database:
+
+- **Migrate sequentially, not in parallel**, unless each DB has its own DMS replication instance
+  and target — a shared DMS instance saturates and CDC latency climbs across all tasks.
+- **Schema/name collisions**: two source DBs with the same schema name cannot co-locate on one
+  target without renaming. Decide up-front: separate RDS/Aurora clusters, or rename schemas via DMS
+  table-mapping transformation rules (`rename` actions).
+- **Cross-database queries / FKs** between the source DBs block consolidation onto separate clusters
+  — those joins must move to the app layer or the DBs must land on the same cluster.
+- **Shared users/grants**: migrate the global `mysql.user` / `pg_roles` grants once, deduplicated,
+  not per-DB (each method's schema-objects step omits grants — see execution-runbooks.md).
+- **Sequence the cutovers**: cut over the least-dependent DB first; keep reverse replication
+  (cutover-procedures.md) running per-DB so each can roll back independently.
+
+### Method Summary
+
+| Method | Migrates Schema Objects? | Downtime | Complexity | Best Size Range |
+|--------|------------------------|----------|-----------|-----------------|
+| mysqldump / pg_dump | ✅ ALL (procs, triggers, views, events) | Minutes-hours | Low | < 50 GB |
+| Percona XtraBackup + S3 | ✅ ALL (physical copy) | Minutes-hours | Medium | 10 GB - multi-TB |
+| DMS Full Load + CDC | ❌ Data only (no procs/triggers/views) | Near-zero | Medium-High | Any size |
+| Aurora Read Replica | ✅ ALL | Seconds | Low | Any (RDS source only) |
+| Snapshot migration | ✅ ALL | Minutes | Low | Any (RDS source only) |
+| Binlog replication | ❌ Data only | Near-zero | High | Any (MySQL/MariaDB) |
+| S3 import (LOAD DATA FROM S3) | ❌ Data only | Depends on load time | Medium | Flat file import |
+| PG logical replication | ❌ Data + DDL (no procs/grants) | Near-zero | Medium | Any (PG 10+) |
+| Blue/Green Deployment | ✅ ALL | < 1 minute | Low | Any (RDS/Aurora source) |
+| Oracle Data Pump (schema/table) | ✅ ALL in-schema objects (procs, triggers, views, sequences); NOT SYS-owned/Scheduler | Minutes-hours | Medium | < 1 TB (Oracle→RDS Oracle) |
+| Oracle transportable tablespaces (XTTS) | ❌ Data/tablespaces only (recreate PL/SQL, views, users via metadata) | Minimal | High | > 1 TB EE (Oracle→RDS Oracle) |
+| SQL Server native backup/restore | ✅ User DB objects; NOT logins/Agent jobs/linked servers (server-level) | Minutes-hours | Low | Any ≤ 64 TiB (SQL Server→RDS SQL Server) |
+
+### Critical Note on Schema Objects
+
+**DMS, binlog replication, and S3 import do NOT migrate:**
+- Stored procedures, functions
+- Triggers
+- Views
+- Events (MySQL)
+- Sequences (PostgreSQL)
+- User grants/permissions
+- Custom data types (PostgreSQL)
+
+**If user needs these migrated → must use dump/restore for schema + chosen method for data**, or use a method that does physical copy (XtraBackup, snapshot, Read Replica).
+
+### Edge-Case Scenarios
+
+**Multi-Database**: see "Multi-Database Scenarios" above.
+
+**Cross-Region**: Requires DMS with cross-region replication. Set up VPC peering or Transit Gateway between source and target regions. Use region-specific KMS keys (encryption keys don't cross regions). Consider Aurora Global Database as the target for ongoing cross-region reads post-migration.
+
+**Cross-Account**: Source and target in different AWS accounts. DMS endpoints use cross-account VPC peering plus IAM roles for access. KMS key policy must grant the target account access for encrypted snapshots. Snapshot sharing requires explicit account grant via modify-db-snapshot-attribute.
+
+**>10 TB or Low Bandwidth (on-prem)**: If estimated transfer time exceeds 7 days, use AWS Snow Family (Snowball Edge) or DataSync for the baseline data. Critical: capture the binlog position or PostgreSQL LSN at the exact point of data export. After the Snow device is loaded into AWS and data is in S3, restore to Aurora and set up CDC replication from the captured position to catch up with changes that occurred during transit.

--- a/db-migration-agent-skill/shared/reference/post-migration.md
+++ b/db-migration-agent-skill/shared/reference/post-migration.md
@@ -1,0 +1,45 @@
+# Post-Migration Operations & Decommission
+
+> Read this during **Phase 9 (Post-Migration)** — after cutover is verified. Alarms and
+> Performance Insights were enabled at provisioning ([preflight-iam-cost.md](preflight-iam-cost.md) §4);
+> this phase is stabilization, tuning back to steady state, and the controlled teardown.
+
+## Immediately after cutover stabilizes (T+1h → T+24h)
+
+1. **Refresh optimizer statistics** — `ANALYZE TABLE` on all tables (MySQL/MariaDB),
+   `ANALYZE` / autovacuum check (PostgreSQL), `DBMS_STATS.GATHER_SCHEMA_STATS` (Oracle),
+   `sp_updatestats` (SQL Server). Most "the new DB is slow" reports trace here.
+2. **Baseline comparison** — re-run the Phase 2 top-20 statement set on the target and
+   diff against the source baseline in `migration-plan.md` (plans, latency). Regressions →
+   [validation-patterns.md](validation-patterns.md) §Performance Baseline and, for
+   major-version gaps, [version-upgrades.md](version-upgrades.md) "After the upgrade".
+3. **Confirm alarms are quiet** and reverse replication lag ≈ 0; record the T+24h check
+   in the plan.
+
+## Return to steady state (after the T+24h watch)
+
+4. **Swap the parameter group** migration → production ([../patterns/cdk-stacks.md](../patterns/cdk-stacks.md)
+   generates both) and apply — note which parameters are reboot-scoped and schedule
+   accordingly. This reverts import-only settings (`innodb_flush_log_at_trx_commit`,
+   relaxed checks) and enforces the production TLS posture.
+5. **Scale down** the instance class to steady-state size (the import-sized instance is
+   pure cost now).
+6. **Restore connection-pool settings** on clients (the 30s `maxLifetime` cutover value →
+   normal production value).
+7. **Verify backups**: automated backup retention as approved, plus a manual snapshot
+   labeled `post-migration-verified`.
+
+## Close the rollback window (default: cutover + 7 days)
+
+8. Confirm with the user the window may close (no open incidents, baseline comparison
+   accepted).
+9. **Stop reverse replication** (the source stops being a warm standby — from here,
+   rollback = restore from snapshot).
+10. **Decommission** — with the explicit-confirmation rule (SKILL.md hard constraint 8),
+    listing exactly what is deleted:
+    - Stop, snapshot (final image), then terminate the source EC2 (or stop if the user
+      keeps it as a cold copy).
+    - Delete DMS tasks, endpoints, then the replication instance.
+    - Remove migration-only security-group rules and the migration stack from the CDK app.
+11. Mark the plan complete: final costs vs the GATE 2 estimate, lessons-learned notes,
+    handover of the CDK project + runbooks to the customer.

--- a/db-migration-agent-skill/shared/reference/preflight-iam-cost.md
+++ b/db-migration-agent-skill/shared/reference/preflight-iam-cost.md
@@ -1,0 +1,106 @@
+# Preflight — Environment Preconditions, IAM, and Cost Estimation
+
+> Run this during **Phase 0 (Preflight)**, before any assessment query. Every check must
+> pass (or be explicitly waived by the user) before proceeding. On failure: **STOP and
+> report** — do not improvise around a missing permission.
+
+## 1. Environment preconditions (agent runs these silently)
+
+```bash
+# Identity + account — confirm you are in the INTENDED account (demo vs customer!)
+aws sts get-caller-identity
+# Region actually configured (must match the user's stated target region)
+aws configure get region
+# Can we see the source? (EC2 source: instance exists, running, SSM-managed?)
+aws ec2 describe-instances --instance-ids $SOURCE_INSTANCE_ID \
+  --query 'Reservations[].Instances[].[State.Name,PrivateIpAddress,IamInstanceProfile.Arn]'
+aws ssm describe-instance-information \
+  --filters Key=InstanceIds,Values=$SOURCE_INSTANCE_ID --query 'InstanceInformationList[].PingStatus'
+# Target engine version actually available in this region (versions churn)
+aws rds describe-db-engine-versions --engine aurora-mysql \
+  --query 'DBEngineVersions[].EngineVersion' --output text | tr '\t' '\n' | tail -5
+# Existing name collisions
+aws rds describe-db-clusters --query "DBClusters[?DBClusterIdentifier=='$TARGET_ID'].Status"
+# Service quotas that block mid-flight: RDS instances (L-7B6409FD), DMS instances
+aws service-quotas get-service-quota --service-code rds --quota-code L-7B6409FD \
+  --query 'Quota.Value'
+# CDK bootstrapped? (only if deploying the CDK project)
+aws cloudformation describe-stacks --stack-name CDKToolkit --query 'Stacks[0].StackStatus' 2>/dev/null
+```
+
+Report results as a table: ✅/❌ per check. Any ❌ → present the fix, wait for the user.
+
+## 2. IAM — what the migration executor needs
+
+Do **not** run a production migration on `AdministratorAccess` out of habit; propose this
+split. Verify effective permissions up front with `aws iam simulate-principal-policy`
+rather than failing at step 14 of the cutover. Additionally, apply the **engagement
+guardrail policy** ([engagement-safety.md](engagement-safety.md) §IAM guardrails):
+read-only session for assessment-only mode, and explicit Denies protecting the source
+(no terminate/stop/delete) until the decommission authorization is signed.
+
+| Role | Used in | Key actions |
+|------|---------|-------------|
+| **migration-operator** (human/agent running the skill) | All phases | `rds:*` on the new cluster + snapshots, `dms:*` on migration resources, `ec2:Describe*`, `ec2:AuthorizeSecurityGroup*` (scoped), `secretsmanager:GetSecretValue/CreateSecret/UpdateSecret` (scoped to the app's secrets), `ssm:StartSession/SendCommand` (scoped to source instances), `cloudwatch:PutMetricAlarm/GetMetricData`, `route53:ChangeResourceRecordSets` (scoped to the zone, only if DNS cutover), `kms:CreateKey/DescribeKey` or use of an existing CMK, `iam:PassRole` for the service roles below |
+| **aurora-s3-import-role** (service role, XtraBackup path) | Phase 6 | `s3:GetObject/ListBucket` on the backup bucket + `kms:Decrypt`; trust `rds.amazonaws.com` |
+| **rds-s3-integration-role** (Oracle Data Pump) / **rds-backup-restore-role** (SQL Server) | Phase 6 | See [execution-runbooks.md](execution-runbooks.md) one-time setup blocks; trust `rds.amazonaws.com`, scope with `aws:SourceArn` |
+| **dms-vpc-role** + **dms-cloudwatch-logs-role** | DMS paths | Exact-name service roles DMS requires in the account (create once per account) |
+| **rds-proxy-secrets-role** | RDS Proxy | `secretsmanager:GetSecretValue` on the DB secret; trust `rds.amazonaws.com` |
+| **rds-monitoring-role** | Enhanced Monitoring | Managed policy `AmazonRDSEnhancedMonitoringRole`; trust `monitoring.rds.amazonaws.com` |
+
+```bash
+# Verify before starting, e.g.:
+aws iam simulate-principal-policy --policy-source-arn $OPERATOR_ARN \
+  --action-names rds:CreateDBCluster dms:CreateReplicationTask \
+    secretsmanager:UpdateSecret ssm:SendCommand route53:ChangeResourceRecordSets \
+  --query 'EvaluationResults[].[EvalActionName,EvalDecision]' --output table
+```
+
+Cross-account/cross-region notes (KMS key policy grants, snapshot sharing) are in
+[method-selection.md](method-selection.md) §Edge-Case Scenarios.
+
+## 3. Cost estimation (present at GATE 2 with the plan)
+
+Give the user an itemized **monthly steady-state** figure and a **one-time migration**
+figure before they approve the plan. Use `awslabs.aws-pricing-mcp-server` when connected
+([mcp-and-tooling.md](mcp-and-tooling.md)); otherwise CLI pricing or the calculator.
+
+**Itemize:**
+
+| Item | Type | Notes |
+|------|------|-------|
+| Aurora/RDS instance(s) — migration size | one-time (days) | Sized up per [target-provisioning.md](target-provisioning.md); scale down after |
+| Aurora/RDS instance(s) — steady-state | monthly | Writer + readers; Multi-AZ doubles RDS instance cost, is built into Aurora |
+| Storage + I/O | monthly | Aurora Standard (pay-per-I/O) vs I/O-Optimized (~+30% instance, free I/O — cheaper when I/O > ~25% of bill) |
+| Backup beyond retention free tier | monthly | |
+| DMS replication instance | one-time (days–weeks) | Runs until rollback window closes (reverse replication!) — budget the full window, not just the load |
+| RDS Proxy | monthly | Priced per vCPU of the target |
+| Data transfer | one-time | Same-region private = free; cross-region/DX/internet ≠ free; Snow Family per-device |
+| Source EC2 kept 7 days post-cutover | one-time | The rollback window is a real cost line |
+| Performance Insights, Enhanced Monitoring, Database Activity Streams | monthly | PI free tier = 7 days retention; DAS has Kinesis costs |
+
+Typical shape of the sanity check to state aloud: *"steady-state moves you from an EC2
+instance you patch yourself to ~$X/mo managed; the migration itself costs ~$Y one-time,
+dominated by the DMS instance and double-running the source for the rollback window."*
+
+## 4. Monitoring baseline (set up BEFORE cutover, not after)
+
+Capture a **pre-migration performance baseline on the source** while it still serves
+production — post-cutover comparisons are meaningless without it:
+
+- Top-20 statements by total time (`performance_schema.events_statements_summary_by_digest`
+  / `pg_stat_statements`) + their `EXPLAIN` plans → `migration-plan.md`.
+- Peak/typical connections, QPS, p95 latency from the app's own metrics.
+
+On the target, enable at provisioning time (all are in the CDK stacks —
+[../patterns/cdk-stacks.md](../patterns/cdk-stacks.md)):
+
+- **Performance Insights** (retention ≥ 7 days) + **Enhanced Monitoring** (60s).
+- **CloudWatch alarms**: `CPUUtilization` > 80%, `FreeableMemory` < 10%, 
+  `DatabaseConnections` > 80% of `max_connections`, `ReadLatency`/`WriteLatency` > 20 ms,
+  `AuroraReplicaLag` > 1000 ms, and during migration `CDCLatencySource`/`CDCLatencyTarget`
+  > 30 s on the DMS task → SNS topic the operator actually watches during cutover.
+- **Log exports** to CloudWatch (error/slowquery/audit as the engine provides).
+
+First-24-hours watchlist after cutover: [validation-patterns.md](validation-patterns.md)
+§Monitoring Checklist.

--- a/db-migration-agent-skill/shared/reference/rds-aurora-limitations.md
+++ b/db-migration-agent-skill/shared/reference/rds-aurora-limitations.md
@@ -1,0 +1,618 @@
+# RDS & Aurora Migration: Limitations, Incompatibilities & Breaking Changes
+
+> **Critical Reference Document** — What breaks, what won't work, and what requires changes when migrating from self-managed databases to Amazon RDS or Aurora.
+
+---
+
+## Table of Contents
+
+1. [Encryption Incompatibilities](#1-encryption-incompatibilities) — incl. §1.6 Korean encryption tools, §1.7 Korean access-control/audit appliances
+2. [Storage Engine Limitations](#2-storage-engine-limitations)
+3. [Authentication Limitations](#3-authentication-limitations)
+4. [Feature Limitations (Privilege & Access)](#4-feature-limitations--privilege--access-restrictions)
+5. [Replication & Topology Limitations](#5-replication--topology-limitations)
+6. [Network & Connectivity Limitations](#6-network--connectivity-limitations)
+7. [Operational Limitations](#7-operational-limitations)
+8. [Data Type, Charset & Timezone Issues](#8-data-type-charset--timezone-issues)
+9. [PostgreSQL-Specific Limitations](#9-postgresql-specific-limitations)
+10. [Summary: Blocker vs. Adjustment Matrix](#10-summary-blocker-vs-adjustment-matrix)
+
+---
+
+## 1. Encryption Incompatibilities
+
+### 1.1 MySQL Transparent Data Encryption (TDE) — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | MySQL InnoDB Tablespace Encryption (TDE) is explicitly **not supported** on RDS for MySQL or Aurora MySQL. The `ENCRYPTION='Y'` clause on `CREATE TABLE` / `ALTER TABLE` and the InnoDB tablespace encryption feature will not function. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🔴 **Blocker** — must redesign encryption approach |
+| **Workaround** | Use RDS/Aurora **at-rest encryption** (AES-256, AWS KMS-managed) which encrypts the entire storage volume, including backups, replicas, and snapshots. This is enabled at instance creation and cannot be changed after. Alternatively, use application-level encryption (encrypt before writing). |
+| **Source** | [AWS Docs: MySQL features not supported](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.FeatureSupport.html) — "InnoDB Tablespace Encryption" listed as unsupported. |
+
+### 1.2 MySQL Keyring Plugin — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | The MySQL `keyring_file`, `keyring_encrypted_file`, `keyring_aws` (Amazon Web Services Keyring Plugin), and all other keyring plugins are **not supported** on RDS/Aurora. Any feature relying on the keyring subsystem (including TDE, encrypted general tablespace, encrypted binary logs) will fail. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🔴 **Blocker** — if your application relies on keyring-based encryption |
+| **Workaround** | Migrate to AWS KMS-based volume encryption. For column-level encryption needs, implement application-side encryption using AWS Encryption SDK, or use functions like `AES_ENCRYPT()`/`AES_DECRYPT()` in MySQL (managing keys externally in AWS Secrets Manager or KMS). |
+| **Source** | [AWS Docs: Known Issues](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.KnownIssuesAndLimitations.html) — "MySQL Keyring Plugin not supported" |
+
+### 1.3 Third-Party Encryption Solutions (Vormetric, Thales CipherTrust, etc.)
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Solutions like Vormetric/Thales CipherTrust that require OS-level agents, file-system level encryption, or kernel modules **cannot be installed** on RDS/Aurora because there is no OS-level access. Solutions requiring custom MySQL plugins also cannot work. |
+| **Affected service** | RDS + Aurora (all engines) |
+| **Severity** | 🔴 **Blocker** — agent-based solutions are incompatible |
+| **Workaround** | Replace with: (1) AWS KMS for at-rest encryption, (2) Application-level encryption with external key management, (3) AWS CloudHSM for FIPS 140-2 Level 3 key storage if regulatory compliance requires it. Some CipherTrust features can map to AWS-native services. |
+
+### 1.4 Column-Level Encryption Approaches
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | MySQL `AES_ENCRYPT()`/`AES_DECRYPT()` functions still work. However, approaches that depend on keyring plugins for key management, or that use InnoDB-native column encryption features, will not function. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🟡 **Requires adjustment** |
+| **Workaround** | Continue using `AES_ENCRYPT()`/`AES_DECRYPT()` with keys stored in AWS Secrets Manager. For PostgreSQL, `pgcrypto` extension IS supported and works normally on both RDS and Aurora PostgreSQL. |
+
+### 1.5 PostgreSQL pgcrypto — SUPPORTED (with caveats)
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | `pgcrypto` extension works on both RDS PostgreSQL and Aurora PostgreSQL. However, you cannot use OS-level key files or custom file paths. Keys must be passed in SQL or managed by the application. |
+| **Affected service** | N/A — this works |
+| **Severity** | 🟢 **Works** — minor adjustment to key management |
+| **Workaround** | Store encryption keys in AWS Secrets Manager rather than OS files. |
+
+### 1.6 Korean DB Encryption Solutions (Petra Cipher, D'Amo, CUBE-One) — MODE-DEPENDENT
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Korean DB encryption products attach in several modes. **DB-engine plug-in mode** (Petra Cipher plug-in; D'Amo DE) and **OS/volume mode** (D'Amo KE) require installing a library into the DBMS engine or onto the host OS — **impossible on managed RDS/Aurora** (no engine-plugin install, no OS access). CUBE-One's install mode is vendor-confirm-required. |
+| **Affected service** | RDS + Aurora (all engines) |
+| **Severity** | 🔴 **Blocker** for plug-in / OS-volume modes |
+| **Workaround** | Switch to the vendor's **API / app-side mode** (Petra Cipher API; D'Amo BA-SCP), which runs encryption on the application server before the query reaches the DB — this survives. Or replace with **RDS/Aurora KMS encryption-at-rest** (the managed TDE equivalent) plus **app-side column encryption** (AWS Encryption SDK + KMS) for field-level needs. ⚠️ If a Korean auditor mandates **SEED/ARIA** for specific fields, that must be done at the app/column layer with a vendor API supporting those ciphers — KMS-at-rest (AES-256) alone does not satisfy a SEED/ARIA *field* mandate. |
+| **Detail** | See [third-party-db-security.md](third-party-db-security.md) §2 and [regulatory-compliance.md](regulatory-compliance.md) §1. |
+
+### 1.7 Korean DB Access-Control / Audit Appliances (Chakra Max, DBSafer, Petra) — MODE-DEPENDENT
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Korean DB access-control/audit tools attach via **network sniffing** (TAP/SPAN/port-mirror) and/or a **host agent** on the DB OS. Managed RDS provides **no port mirroring/SPAN** and **no OS access**, so both modes break. |
+| **Affected service** | RDS + Aurora (all engines) |
+| **Severity** | 🔴 **Blocker** for sniffing / host-agent modes |
+| **Workaround** | Move to the vendor's **inline gateway/proxy mode** deployed in the VPC in front of the RDS endpoint (DBSafer's native mode; Chakra Max Software-TAP; Petra Gateway), and force all client traffic through it via security groups + route design. Replace the audit trail with **Amazon RDS/Aurora Database Activity Streams (DAS)** — explicitly designed for third-party compliance-tool integration — plus engine audit (`pgaudit`, MariaDB Audit Plugin, SQL Server Audit) and **RDS Proxy + IAM auth** for connection control. |
+| **Detail** | See [third-party-db-security.md](third-party-db-security.md) §1 and §4. |
+
+---
+
+## 2. Storage Engine Limitations
+
+### 2.1 MyISAM Tables
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | **On RDS MySQL**: MyISAM tables are technically supported but with significant caveats — they do NOT support reliable crash recovery, Point-In-Time Restore (PITR), or snapshot restore. Data can be lost/corrupted after crash recovery. **On Aurora MySQL**: MyISAM is **NOT supported for user data tables**. Aurora ONLY supports InnoDB for user tables. All MyISAM tables must be converted to InnoDB before migration. |
+| **Affected service** | RDS MySQL (degraded), Aurora MySQL (blocked) |
+| **Severity** | 🔴 **Blocker for Aurora**, 🟡 **Risky on RDS** |
+| **Workaround** | Convert all MyISAM tables to InnoDB before migration: `ALTER TABLE schema.table_name ENGINE=InnoDB, ALGORITHM=COPY;` — Note: InnoDB tables may be larger than MyISAM equivalents and have different locking/performance characteristics (row-level vs table-level locking). |
+| **Source** | [AWS Docs: Supported storage engines](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.FeatureSupport.html), [Aurora migration prechecks](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.ExtMySQL.Prechecks.html) |
+
+### 2.2 FEDERATED Storage Engine — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | The FEDERATED storage engine is explicitly not supported on RDS for MySQL. Tables using this engine cannot be created or migrated. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🔴 **Blocker** if you use FEDERATED tables |
+| **Workaround** | Replace with: (1) MySQL `mysql_fdw` / direct queries over network, (2) Application-level data federation, (3) AWS Database Migration Service for data synchronization, (4) Views over linked tables using other mechanisms. |
+| **Source** | [AWS Docs: MySQL feature support](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.FeatureSupport.html) |
+
+### 2.3 MEMORY (HEAP) Engine Tables
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | MEMORY engine tables work on RDS MySQL but data is lost on restart/failover (as expected for MEMORY engine). On Aurora, MEMORY tables have the same behavior. The issue is that in Aurora's shared-storage architecture with potential automatic failover, data loss from MEMORY tables becomes more likely and less predictable. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🟡 **Requires adjustment** — consider architecture implications |
+| **Workaround** | Replace MEMORY tables with InnoDB tables or use ElastiCache (Redis/Memcached) for caching workloads. For temporary processing, use InnoDB temp tables. |
+
+### 2.4 ARCHIVE and BLACKHOLE Engines
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | ARCHIVE and BLACKHOLE engines are available on RDS MySQL but are not officially recommended. On Aurora MySQL, only InnoDB is supported for user tables — ARCHIVE and BLACKHOLE will not work. |
+| **Affected service** | Aurora MySQL (blocked) |
+| **Severity** | 🟡 **Requires adjustment for Aurora** |
+| **Workaround** | ARCHIVE → Migrate data to InnoDB with appropriate compression, or archive to S3 via Data Pipeline. BLACKHOLE → Replace with binlog replication filters or application logic. |
+
+### 2.5 Compressed Tables / Pages (Aurora-specific)
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Aurora MySQL does NOT support compressed tables (`ROW_FORMAT=COMPRESSED`) or page compression (`COMPRESSION = 'zlib'|'lz4'`). Tables created with these options must be decompressed before migration. |
+| **Affected service** | Aurora MySQL |
+| **Severity** | 🔴 **Blocker for Aurora** if using compressed tables |
+| **Workaround** | Before migration, alter tables: `ALTER TABLE t ROW_FORMAT=DYNAMIC;` and `ALTER TABLE t COMPRESSION='none';` — Note: This will increase storage usage. |
+| **Source** | [Aurora MySQL migration prechecks](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.ExtMySQL.Prechecks.html) |
+
+### 2.6 InnoDB Page Compression (RDS-specific)
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Starting February 2024, all newly created RDS MySQL DB instances have a file system block size of 16KB. InnoDB page compression requires the file system block size to be smaller than the InnoDB page size. Since the default InnoDB page size is also 16KB, page compression **does not work** on new RDS instances. |
+| **Affected service** | RDS MySQL (new instances from Feb 2024) |
+| **Severity** | 🟡 **Requires adjustment** |
+| **Workaround** | Do not rely on InnoDB page compression. Use standard InnoDB compression (`ROW_FORMAT=COMPRESSED`) on RDS, or accept slightly higher storage usage. |
+| **Source** | [AWS Known Issues](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.KnownIssuesAndLimitations.html) |
+
+### 2.7 Custom/Third-Party Storage Engines
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Any custom-compiled or third-party storage engines (TokuDB, RocksDB/MyRocks, Spider, etc.) are **not available** on RDS or Aurora. You cannot install custom engine plugins. |
+| **Affected service** | RDS + Aurora (all MySQL variants) |
+| **Severity** | 🔴 **Blocker** if dependent on custom engines |
+| **Workaround** | Migrate to InnoDB. For TokuDB compression benefits, consider Aurora's storage efficiency or RDS with gp3 storage. For RocksDB write-optimization, test InnoDB with appropriate buffer pool tuning. |
+
+---
+
+## 3. Authentication Limitations
+
+### 3.1 PAM Authentication Plugin — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | PAM (Pluggable Authentication Modules) authentication is not available on RDS or Aurora. You cannot use OS-level PAM configurations for database authentication. |
+| **Affected service** | RDS + Aurora (MySQL and PostgreSQL) |
+| **Severity** | 🔴 **Blocker** if PAM is your primary auth method |
+| **Workaround** | Replace with: (1) IAM Database Authentication (token-based, supported for MySQL and PostgreSQL), (2) Kerberos/Active Directory authentication (supported for both RDS and Aurora PostgreSQL and MySQL), (3) Standard MySQL native authentication. |
+
+### 3.2 LDAP Authentication Plugin (MySQL) — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | The MySQL Enterprise LDAP authentication plugins (`authentication_ldap_simple`, `authentication_ldap_sasl`) are not available on RDS or Aurora MySQL. Direct LDAP authentication against MySQL is not possible. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🔴 **Blocker** if using MySQL LDAP auth |
+| **Workaround** | Use Kerberos authentication via AWS Managed Microsoft AD (which can trust on-premises AD/LDAP). This provides centralized authentication with similar functionality. Alternatively, use IAM database authentication with identity federation. |
+
+### 3.3 Custom Authentication Plugins — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Any custom-compiled authentication plugins cannot be installed. The only authentication plugins available are those pre-installed by AWS: `mysql_native_password`, `caching_sha2_password`, and `AWSAuthenticationPlugin` (for IAM auth). The "Authentication Plugin" category is explicitly listed as unsupported. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🔴 **Blocker** if using custom auth plugins |
+| **Workaround** | Migrate to supported authentication: native MySQL auth, IAM database auth, or Kerberos via AWS Directory Service. |
+| **Source** | [AWS Docs: Features not supported](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.FeatureSupport.html) |
+
+### 3.4 Default Authentication Plugin Changes
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | RDS MySQL 8.0.34+ forces `mysql_native_password` as default (you cannot change it). RDS MySQL 8.4+ uses `caching_sha2_password` by default. Client applications using older MySQL connectors that don't support `caching_sha2_password` will fail to connect to 8.4 instances. |
+| **Affected service** | RDS MySQL |
+| **Severity** | 🟡 **Requires adjustment** — update client libraries |
+| **Workaround** | Update MySQL client connectors/drivers to versions supporting `caching_sha2_password`, or change the `authentication_policy` parameter for MySQL 8.4. Ensure TLS is configured (required for `caching_sha2_password` RSA key exchange). |
+
+### 3.5 PostgreSQL pg_hba.conf — NO DIRECT ACCESS
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | You cannot directly edit `pg_hba.conf` on RDS/Aurora PostgreSQL. Authentication methods configured via `pg_hba.conf` (like `cert`, `ident`, `peer`, custom PAM) cannot be configured in the traditional way. |
+| **Affected service** | RDS PostgreSQL + Aurora PostgreSQL |
+| **Severity** | 🟡 **Requires adjustment** |
+| **Workaround** | Authentication is controlled via: (1) VPC Security Groups (network-level access), (2) `rds.force_ssl` parameter for SSL requirements, (3) IAM database authentication, (4) Kerberos via AWS Directory Service, (5) Standard password authentication. The `rds.accepted_password_auth_method` parameter controls allowed methods. |
+
+### 3.6 Certificate-Based Client Authentication Differences
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | RDS/Aurora provides server-side certificates for TLS but client certificate authentication (mutual TLS where the server validates client certs) is limited. You cannot configure arbitrary CA certificates for client validation. For MySQL, `REQUIRE X509` works but certificate management differs from self-managed. |
+| **Affected service** | RDS + Aurora (both engines) |
+| **Severity** | 🟡 **Requires adjustment** |
+| **Workaround** | Use IAM database authentication as a replacement for certificate-based auth. For MySQL, `REQUIRE SSL` and `REQUIRE X509` still function with RDS-provided certificates. |
+
+---
+
+## 4. Feature Limitations — Privilege & Access Restrictions
+
+### 4.1 SUPER Privilege — NOT AVAILABLE
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | The `SUPER` privilege is **never granted** to any user on RDS/Aurora. This breaks: (1) `SET GLOBAL` for certain variables, (2) Creating stored procedures/triggers/events with a different DEFINER, (3) `CHANGE MASTER TO` directly, (4) Killing sessions owned by other users directly, (5) Some `mysqldump` imports that include DEFINER clauses, (6) Setting `gtid_purged`, (7) Binary log administration. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🔴 **Major impact** — affects many DBA operations |
+| **Workaround** | (1) Use `rds_superuser_role` (MySQL 8.0.36+) which provides dynamic privileges replacing SUPER, (2) Remove DEFINER clauses from dump files or use `--set-gtid-purged=OFF`, (3) Use `CALL mysql.rds_kill(thread_id)` instead of `KILL`, (4) Use parameter groups for global variable changes, (5) Use stored procedures `mysql.rds_set_external_source()` for replication config. |
+| **Source** | [Master user privileges](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.MasterAccounts.html) |
+
+### 4.2 File System Access (LOAD DATA INFILE / SELECT INTO OUTFILE) — RESTRICTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | `LOAD DATA LOCAL INFILE` works (reads from client). `LOAD DATA INFILE` (server-side file read) does NOT work — no filesystem access. `SELECT ... INTO OUTFILE` does NOT work for writing to local filesystem. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🔴 **Blocker** for workflows using server-side file operations |
+| **Workaround** | (1) `LOAD DATA LOCAL INFILE` reads from client machine, (2) For Aurora MySQL: `LOAD DATA FROM S3` and `SELECT INTO OUTFILE S3` provide S3 integration, (3) For RDS MySQL: Import from S3 using backup/restore, use `mysqlimport` with `--local` flag, (4) For exports: Use `mysqldump`, or query and export from application. |
+| **Source** | [Aurora S3 integration](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.SaveIntoS3.html) |
+
+### 4.3 User-Defined Functions (UDFs) — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | C-language UDFs (compiled shared libraries loaded via `CREATE FUNCTION ... SONAME`) are **completely impossible** on RDS/Aurora. You cannot upload `.so` files or install native-code UDFs. This is distinct from stored functions (which ARE supported). |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🔴 **Blocker** if using C-compiled UDFs |
+| **Workaround** | (1) Rewrite UDF logic as stored functions (SQL/procedural), (2) Move logic to application layer, (3) Use AWS Lambda functions invoked from Aurora MySQL (`lambda_sync`/`lambda_async`), (4) For PostgreSQL: Use Trusted Language Extensions (pg_tle) for custom extensions in safe languages. |
+
+### 4.4 Custom Plugins — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | No custom MySQL plugins can be installed. Explicitly unsupported: Password Strength Plugin, Rewriter Query Rewrite Plugin, InnoDB full-text parser plugin, X Plugin (mysqlx/port 33060), Group Replication Plugin, Semisynchronous replication plugin (except Multi-AZ DB clusters). |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🔴 **Blocker** if dependent on custom plugins |
+| **Workaround** | Per-plugin alternatives: Password Strength → use application-side validation or AWS Secrets Manager password policies. Query Rewrite → ProxySQL/application-level rewriting. X Plugin → blocked, port 33060 is blocked on RDS. |
+| **Source** | [AWS Docs: Features not supported](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.FeatureSupport.html) |
+
+### 4.5 Operating System Access — NONE
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | No SSH, no shell access, no Telnet, no RDP. This means: (1) No cron jobs on the DB server, (2) No shell scripts, (3) No custom monitoring agents on the DB host, (4) No OS-level file manipulation, (5) No custom kernel tuning, (6) No direct access to data directory, (7) No manual binary log manipulation. |
+| **Affected service** | RDS + Aurora (all engines) |
+| **Severity** | 🔴 **Fundamental architecture difference** |
+| **Workaround** | (1) Replace cron with Amazon EventBridge + Lambda, (2) Replace shell scripts with Lambda or Step Functions, (3) Use CloudWatch for monitoring, (4) Use Performance Insights for DB-level metrics, (5) Consider RDS Custom (for Oracle or SQL Server) which provides OS access if absolutely required. |
+
+### 4.6 Binary Log Access Differences
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Direct access to binary logs is restricted. You cannot use `PURGE BINARY LOGS`, cannot directly manage binlog files, and `mysqlbinlog` utility access is available but controlled. Binary logs are retained according to the `binlog retention hours` setting (via stored procedure `mysql.rds_set_configuration`). You cannot access binlog files from replica instances on Aurora. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🟡 **Requires adjustment** |
+| **Workaround** | (1) Use `mysql.rds_set_configuration('binlog retention hours', N)` — max 2160 hours (90 days), (2) Use `SHOW BINARY LOGS` and `mysqlbinlog` utility for download/streaming, (3) For Aurora: Enhanced binlog reduces performance overhead. |
+
+### 4.7 Persisted System Variables — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | MySQL 8.0's `SET PERSIST` and `SET PERSIST_ONLY` commands do not work. The `mysqld-auto.cnf` file mechanism is unavailable. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🟡 **Requires adjustment** |
+| **Workaround** | Use Parameter Groups. All persistent configuration changes must be made through AWS Parameter Groups (DB or Cluster parameter groups). Dynamic parameters can be changed immediately; static parameters require reboot. |
+
+### 4.8 Custom my.cnf / postgresql.conf Settings
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Not all MySQL/PostgreSQL configuration parameters are exposed in Parameter Groups. Some parameters are locked (e.g., `datadir`, `innodb_data_file_path`, `server_id`, `port` to some extent). Some parameters have restricted ranges. Parameters requiring SUPER privilege to set dynamically may need parameter group changes + reboot. |
+| **Affected service** | RDS + Aurora (both engines) |
+| **Severity** | 🟡 **Requires adjustment** |
+| **Workaround** | Review all custom settings and map to available parameters. Use `aws rds describe-db-parameters` to see available/modifiable parameters. Accept that some low-level OS/filesystem tuning is managed by AWS. |
+
+---
+
+## 5. Replication & Topology Limitations
+
+### 5.1 MySQL Group Replication — NOT SUPPORTED (standard RDS)
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | The MySQL Group Replication plugin is not available on standard RDS MySQL or Aurora MySQL (version 2). However, RDS MySQL 8.4 introduced active-active clusters based on Group Replication. Aurora MySQL version 3 doesn't support the Group Replication plugin in the traditional sense — Aurora uses its own replication mechanism. |
+| **Affected service** | Aurora MySQL (all versions), RDS MySQL (versions prior to 8.4) |
+| **Severity** | 🟡 **Requires architecture change** |
+| **Workaround** | (1) For Aurora: Aurora's native replication (shared storage) provides better availability than Group Replication, (2) For RDS MySQL 8.4+: Active-active clusters are available, (3) Aurora Global Database for cross-region replication. |
+
+### 5.2 Galera Cluster Features — NOT AVAILABLE
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Galera Cluster (used by MariaDB Cluster, Percona XtraDB Cluster) is a synchronous multi-master replication system. It is completely unavailable on RDS/Aurora. Galera-specific features (wsrep, SST/IST, flow control, certification-based replication) do not exist. |
+| **Affected service** | RDS + Aurora (all MySQL/MariaDB variants) |
+| **Severity** | 🔴 **Blocker** — requires complete architecture redesign |
+| **Workaround** | (1) Aurora multi-AZ with read replicas (one writer, up to 15 readers), (2) Aurora Global Database for cross-region, (3) RDS MySQL 8.4 active-active clusters, (4) For true multi-master write: consider Amazon DynamoDB or application-level sharding. |
+
+### 5.3 Multi-Source Replication
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Multi-source replication (one replica receiving from multiple sources) was NOT supported on Aurora MySQL (version 2 explicitly lists it as unsupported). For RDS MySQL 8.0.35+, multi-source replication IS now supported. |
+| **Affected service** | Aurora MySQL (not supported) |
+| **Severity** | 🟡 **Requires adjustment** for Aurora |
+| **Workaround** | For RDS MySQL: Use multi-source replication natively (supported 8.0.35+). For Aurora: Consolidate data from multiple sources at application level, or use intermediate RDS MySQL instance as aggregator before feeding to Aurora. |
+| **Source** | [Aurora MySQL v2 limitations](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.CompareMySQL57.html), [RDS multi-source](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql-multi-source-replication.html) |
+
+### 5.4 Replication Filtering (Aurora MySQL v2)
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Aurora MySQL version 2 did NOT support replication filtering. Aurora MySQL version 3 (MySQL 8.0 compatible) DOES support replication filtering. |
+| **Affected service** | Aurora MySQL version 2 (resolved in v3) |
+| **Severity** | 🟢 **Resolved in current versions** |
+| **Workaround** | Upgrade to Aurora MySQL version 3. |
+
+### 5.5 Read Replica Limits
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | RDS MySQL: Maximum 15 read replicas per primary (up from previous 5). Aurora: Maximum 15 Aurora Replicas per cluster. Cross-region read replicas have additional lag. You cannot create a replica of a replica (no cascading). |
+| **Affected service** | RDS + Aurora |
+| **Severity** | 🟢 **Generally sufficient** — 15 is generous |
+| **Workaround** | If you need more than 15 read endpoints, use RDS Proxy for connection pooling/multiplexing, or implement read-side caching (ElastiCache). |
+
+---
+
+## 6. Network & Connectivity Limitations
+
+### 6.1 No Direct Server Access (SSH/SSM)
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | No SSH, SSM Session Manager, Telnet, or RDP access to the DB host. This is a fundamental aspect of the managed service. You cannot troubleshoot at the OS level. |
+| **Affected service** | RDS + Aurora (all engines) |
+| **Severity** | 🟡 **Fundamental design — adjust workflows** |
+| **Workaround** | Use Enhanced Monitoring (OS-level metrics), Performance Insights, CloudWatch, and database-level diagnostic queries. For OS-level access needs, consider RDS Custom (Oracle/SQL Server only). |
+
+### 6.2 Custom Port Restrictions
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | RDS does support custom ports (you can choose during creation). However, **port 33060 is explicitly blocked** for MySQL (X Protocol port). You must choose a different port if you were using 33060. Standard ports: MySQL 3306, PostgreSQL 5432. |
+| **Affected service** | RDS MySQL |
+| **Severity** | 🟢 **Minor** — custom ports work except 33060 |
+| **Workaround** | Use any port except 33060 for MySQL. |
+| **Source** | [AWS Known Issues](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.KnownIssuesAndLimitations.html) |
+
+### 6.3 Multi-VPC Access Patterns
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | RDS/Aurora instances reside in a specific VPC. Accessing from other VPCs requires explicit networking setup. Cross-VPC access is not automatic. |
+| **Affected service** | RDS + Aurora |
+| **Severity** | 🟡 **Requires networking setup** |
+| **Workaround** | (1) VPC Peering between VPCs, (2) AWS Transit Gateway for hub-and-spoke, (3) PrivateLink/VPC Endpoints (available for RDS Proxy), (4) For Aurora: Custom endpoints can serve specific workloads but don't solve cross-VPC by themselves. |
+
+### 6.4 On-Premises Connectivity
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Self-managed databases on-premises may have been directly accessible on the local network. RDS/Aurora requires AWS network connectivity. |
+| **Affected service** | RDS + Aurora |
+| **Severity** | 🟡 **Requires networking infrastructure** |
+| **Workaround** | (1) AWS Direct Connect for dedicated private connectivity, (2) AWS Site-to-Site VPN, (3) RDS instances can be made publicly accessible (not recommended for production), (4) VPN + Security Groups for controlled access. |
+
+### 6.5 Public IP Address Behavior
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | When publicly accessible, RDS uses a DNS name that resolves to a public IP. The IP can change during failover. Applications hardcoding IPs will break. |
+| **Affected service** | RDS + Aurora |
+| **Severity** | 🟡 **Design consideration** |
+| **Workaround** | Always use DNS endpoint names, never hardcode IPs. Use appropriate DNS TTL settings in clients. |
+
+---
+
+## 7. Operational Limitations
+
+### 7.1 Maintenance Windows — Mandatory Patching
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | AWS **can and will** apply mandatory security patches and OS updates during your maintenance window, even if you haven't requested them. In critical security cases, patching may occur even with auto minor version upgrade disabled. You cannot indefinitely defer mandatory patches. |
+| **Affected service** | RDS + Aurora |
+| **Severity** | 🟡 **Operational risk** — brief downtime during patching |
+| **Workaround** | (1) Set maintenance window during lowest-traffic period, (2) Aurora supports Zero-Downtime Patching (ZDP) for some patches, (3) Use Multi-AZ for automatic failover during maintenance (30-60 sec), (4) Blue/Green Deployments for controlled major upgrades, (5) Subscribe to RDS events for advance notification. |
+| **Source** | [Aurora maintenance](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.Maintenance.html) |
+
+### 7.2 Version Upgrade Paths — MySQL-family Cannot Skip Major Versions
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | MySQL-family upgrades cannot skip major versions: **no direct 5.7 → 8.4**  — must go 5.7 → 8.0 → 8.4. Each major version upgrade requires prechecks and may require application changes. Aurora MySQL v2 → v3 is a major upgrade. Automatic minor version upgrades can be forced by AWS when a version reaches end-of-support. |
+| **Affected service** | RDS + Aurora |
+| **Severity** | 🟡 **Planning required** |
+| **Workaround** | (1) Plan upgrade path early, (2) Test with Blue/Green Deployments, (3) Budget time for prechecks and application compatibility testing, (4) For Aurora: Use clones for testing upgrades. |
+| **Source** | [AWS Known Issues](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.KnownIssuesAndLimitations.html) |
+
+### 7.3 Storage Limits and Types
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | **RDS storage limits**: gp2/gp3: 20 GiB–64 TiB, io1/io2: 100 GiB–64 TiB (io2 supports up to 256 TiB with additional volumes). **Storage cannot be decreased** once allocated — only increased. Storage autoscaling has thresholds. **Aurora storage**: Automatically scales up to 128 TiB per cluster. You cannot manually set storage size. Storage shrinks automatically when data is deleted (with dynamic resizing). |
+| **Affected service** | RDS (EBS-backed), Aurora (custom storage) |
+| **Severity** | 🟡 **Design consideration** |
+| **Workaround** | For RDS: Enable storage autoscaling, set appropriate maximums. For Aurora: Storage is automatic — no action needed but understand that storage volume grows in 10 GB segments. |
+
+### 7.4 IOPS Provisioning Differences
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | **gp2**: IOPS tied to volume size (3 IOPS/GiB, burst to 3000), cannot provision independently. **gp3**: Baseline 3000 IOPS/125 MiB/s, can provision up to 64,000 IOPS independently. **io1**: Up to 64,000 IOPS. **io2**: Up to 256,000 IOPS. **Aurora**: IOPS are NOT user-provisioned — Aurora manages I/O automatically. Aurora I/O-Optimized pricing tier available for I/O-heavy workloads. Self-managed servers with local NVMe/SSD may have different IOPS profiles. |
+| **Affected service** | RDS + Aurora |
+| **Severity** | 🟡 **Performance tuning required** |
+| **Workaround** | Benchmark on target instance class. For RDS: Choose appropriate storage type based on IOPS needs. For Aurora: I/O-Optimized cluster configuration for predictable costs. |
+
+### 7.5 Backup Limitations
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | (1) Automated backup retention: 0–35 days maximum (default 7), (2) Cannot take filesystem-level snapshots yourself, (3) Backups cannot overlap with maintenance window, (4) Cross-region automated backup replication limited to 20 per region, (5) Multi-AZ DB clusters do NOT support automated backup replication, (6) You cannot restore to the same instance — must create new instance from snapshot, (7) PITR (Point-in-Time Recovery) creates a new instance. |
+| **Affected service** | RDS + Aurora |
+| **Severity** | 🟡 **Operational adjustment** |
+| **Workaround** | (1) Use AWS Backup for longer retention (up to 100 years) and cross-region/cross-account, (2) Manual snapshots have no retention limit (but count toward quota of 100), (3) Understand RTO: restore from snapshot creates new instance (DNS endpoint changes). |
+
+### 7.6 Storage-Full Behavior (RDS MySQL)
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | When storage becomes full, RDS automatically **STOPS** the DB instance to prevent metadata corruption. The instance becomes unavailable. Thresholds: <200 MiB free (for instances <20 GB), <1024 MiB free (>100 GB), or <1% free (20-100 GB). |
+| **Affected service** | RDS MySQL |
+| **Severity** | 🔴 **Can cause downtime** |
+| **Workaround** | (1) Enable storage autoscaling with appropriate max, (2) Set CloudWatch alarms on `FreeStorageSpace`, (3) Monitor actively — unlike self-managed where the DB might slow down but remain accessible. |
+
+---
+
+## 8. Data Type, Charset & Timezone Issues
+
+### 8.1 Character Set / Collation Issues During Migration
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | (1) `lower_case_table_names=2` is NOT supported on RDS (only 0 or 1), (2) For MySQL 8.0/8.4: `lower_case_table_names` cannot be changed after instance creation, (3) Default charset changed from `latin1`→`utf8mb4` in MySQL 8.0 — if migrating from older self-managed instances, explicit charset settings are important, (4) Parameter group changes for charset require careful ordering (parameter group → create instance). |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🟡 **Requires careful planning** |
+| **Workaround** | (1) Set `lower_case_table_names` in parameter group BEFORE creating the instance, (2) Verify all table/column charsets match expectations, (3) Use `mysqldump --default-character-set=utf8mb4` for migration, (4) Test with production data queries before cutover. |
+| **Source** | [AWS Known Issues](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.KnownIssuesAndLimitations.html) |
+
+### 8.2 Timezone Data Differences
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | (1) RDS MySQL stores timestamps internally as UTC — timezone conversion happens at session level, (2) If migrating from a source database with non-UTC `system_time_zone`, timestamp data may appear shifted, (3) RDS populates timezone tables but they may not be updated as frequently as self-managed (use `mysql.rds_set_configuration` or parameter groups), (4) `TIMESTAMP` columns are affected by timezone settings during DMS migration. |
+| **Affected service** | RDS MySQL + Aurora MySQL |
+| **Severity** | 🟡 **Data integrity risk if not planned** |
+| **Workaround** | (1) Ensure source and target timezone settings match during migration, (2) Use `DATETIME` instead of `TIMESTAMP` when timezone independence is needed, (3) Set session `time_zone` explicitly in applications, (4) For DMS migrations from non-UTC sources: see [AWS Knowledge Center guidance](https://www.repost.aws/knowledge-center/dms-migrate-mysql-non-utc). |
+
+### 8.3 Spatial Data Type Support
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Spatial data types (`GEOMETRY`, `POINT`, `LINESTRING`, `POLYGON`) are generally supported on RDS MySQL and Aurora MySQL. However, Aurora parallel query now supports these types (since v3). Spatial indexes work. The main issue is with migration tools — some DMS versions handle spatial columns differently. |
+| **Affected service** | Minimal impact |
+| **Severity** | 🟢 **Generally supported** |
+| **Workaround** | Test spatial queries after migration. Ensure DMS task settings handle spatial columns correctly. |
+
+---
+
+## 9. PostgreSQL-Specific Limitations
+
+### 9.1 No Superuser Access
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | The `postgres` superuser role is not available. Instead, `rds_superuser` is the highest-privileged role. Cannot: (1) `CREATE EXTENSION` for extensions not on the approved list, (2) Access `pg_hba.conf`, (3) Use `ALTER SYSTEM`, (4) Create C-language functions, (5) Load custom shared libraries, (6) Access the filesystem directly. |
+| **Affected service** | RDS PostgreSQL + Aurora PostgreSQL |
+| **Severity** | 🟡 **Requires adjustment** — most DBA tasks have alternatives |
+| **Workaround** | `rds_superuser` role can: create roles, databases, install supported extensions, manage replication slots, terminate backends. For extension management, use delegated extension support or Trusted Language Extensions (pg_tle). |
+
+### 9.2 Unsupported/Unavailable PostgreSQL Extensions
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | Only extensions listed in `rds.extensions` parameter are available. Notable MISSING extensions on RDS/Aurora PostgreSQL include: `pgrouting`, `timescaledb`, `citus` (community), `pg_partman` (available on some versions), custom C extensions, any extension requiring filesystem access or superuser. The list varies by PostgreSQL version. |
+| **Affected service** | RDS PostgreSQL + Aurora PostgreSQL |
+| **Severity** | 🔴 **Blocker** if dependent on unavailable extensions |
+| **Workaround** | (1) Check `SHOW rds.extensions;` to see available extensions, (2) Use Trusted Language Extensions (pg_tle) for custom functionality in safe languages (PL/pgSQL, JavaScript, Perl), (3) For unsupported extensions: rewrite functionality in application layer or available extensions. |
+
+### 9.3 Custom C-Language Extensions — NOT SUPPORTED
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | You cannot install any custom-compiled C extensions. `CREATE FUNCTION ... LANGUAGE C` requires superuser and filesystem access, both unavailable. |
+| **Affected service** | RDS PostgreSQL + Aurora PostgreSQL |
+| **Severity** | 🔴 **Blocker** if using custom C extensions |
+| **Workaround** | (1) Trusted Language Extensions (pg_tle) for custom PostgreSQL extensions in safe languages, (2) Rewrite in PL/pgSQL, PL/Python, or PL/Perl (available on RDS), (3) Move compute to Lambda/application layer. |
+
+### 9.4 Logical Replication Restrictions
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | RDS PostgreSQL supports logical replication but with restrictions: (1) Must set `rds.logical_replication=1` in parameter group, (2) Requires `wal_level=logical` (automatic when above is set), (3) `max_replication_slots` has limits per instance class, (4) Cannot use `pg_recvlogical` directly from the DB host. |
+| **Affected service** | RDS PostgreSQL + Aurora PostgreSQL |
+| **Severity** | 🟡 **Requires configuration** |
+| **Workaround** | Configure through parameter groups. Logical replication works well for migration scenarios (DMS uses it). Monitor replication slot growth. |
+
+### 9.5 CHECKPOINT and Vacuum Control
+
+| Aspect | Detail |
+|--------|--------|
+| **What breaks** | The `rds_superuser` can run `CHECKPOINT` but cannot tune checkpoint-related parameters beyond what's in parameter groups. Some vacuum parameters are adjusted by AWS automatically. You cannot run `VACUUM FULL` on system catalogs without `rds_superuser`. |
+| **Affected service** | RDS PostgreSQL + Aurora PostgreSQL |
+| **Severity** | 🟢 **Minor** |
+| **Workaround** | `rds_superuser` role grants `CHECKPOINT` privilege. Tune vacuum via parameter groups (`autovacuum_*` parameters). |
+
+---
+
+## 10. Summary: Blocker vs. Adjustment Matrix
+
+### 🔴 Hard Blockers (Must Resolve Before Migration)
+
+| Item | Affected Service | Must Do |
+|------|-----------------|---------|
+| MySQL TDE / InnoDB Tablespace Encryption | RDS + Aurora | Switch to KMS volume encryption |
+| MySQL Keyring Plugin | RDS + Aurora | Remove keyring dependencies |
+| MyISAM tables | Aurora | Convert to InnoDB |
+| Compressed tables (`ROW_FORMAT=COMPRESSED`) | Aurora | Decompress before migration |
+| FEDERATED storage engine | RDS + Aurora | Redesign data access |
+| Custom storage engines (TokuDB, RocksDB) | RDS + Aurora | Migrate to InnoDB |
+| C-language UDFs | RDS + Aurora | Rewrite as stored functions or Lambda |
+| Custom plugins | RDS + Aurora | Find managed alternatives |
+| PAM/LDAP authentication | RDS + Aurora | Switch to IAM/Kerberos auth |
+| Galera Cluster | RDS + Aurora | Architecture redesign |
+| Third-party OS-level encryption agents | RDS + Aurora | Switch to AWS-native encryption |
+| Korean DB encryption in plug-in / OS-volume mode (Petra Cipher, D'Amo DE/KE, CUBE-One) | RDS + Aurora | Switch to vendor API mode or KMS + app-side encryption — see [third-party-db-security.md](third-party-db-security.md) |
+| Korean DB access/audit in sniffing / host-agent mode (Chakra Max, DBSafer agent, Petra sniffing) | RDS + Aurora | Vendor gateway mode in VPC + Database Activity Streams — see [third-party-db-security.md](third-party-db-security.md) |
+| Custom C extensions (PostgreSQL) | RDS + Aurora | Use pg_tle or rewrite |
+| Unsupported PostgreSQL extensions | RDS + Aurora | Verify with `SHOW rds.extensions` |
+
+### 🟡 Requires Adjustment (Needs Work But Solvable)
+
+| Item | Affected Service | Action |
+|------|-----------------|--------|
+| SUPER privilege loss | RDS + Aurora MySQL | Use `rds_superuser_role`, stored procedures |
+| File system access (INFILE/OUTFILE) | RDS + Aurora | Use S3 integration, client-side loading |
+| Binary log management | RDS + Aurora | Use RDS stored procedures |
+| OS access (cron, scripts) | RDS + Aurora | EventBridge + Lambda |
+| pg_hba.conf access | RDS + Aurora PG | Security Groups + parameter groups |
+| Maintenance window patching | RDS + Aurora | Schedule + Multi-AZ + ZDP |
+| Version upgrade path | RDS + Aurora | Plan sequential upgrades |
+| Custom port 33060 blocked | RDS MySQL | Use different port |
+| `lower_case_table_names=2` | RDS MySQL | Use 0 or 1 only |
+| Persisted system variables | RDS + Aurora | Use Parameter Groups |
+| Storage can only increase | RDS | Plan storage carefully, enable autoscaling |
+| Timezone data migration | RDS + Aurora | Match timezone settings, test |
+| Multi-source replication | Aurora MySQL | Use RDS MySQL or consolidate differently |
+
+### 🟢 Works / Minor Differences
+
+| Item | Notes |
+|------|-------|
+| pgcrypto | Fully supported on RDS/Aurora PostgreSQL |
+| Kerberos authentication | Supported via AWS Managed AD |
+| IAM database authentication | Supported for MySQL and PostgreSQL |
+| Spatial data types | Supported |
+| JSON functions (MySQL 8.0) | Supported |
+| Custom ports (except 33060) | Supported |
+| Read replicas (up to 15) | Supported |
+| Replication filtering (Aurora v3) | Supported |
+| TLS/SSL connections | Supported (TLS 1.2/1.3) |
+| InnoDB buffer pool warming | Supported |
+
+---
+
+## References
+
+- [RDS MySQL Known Issues and Limitations](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.KnownIssuesAndLimitations.html)
+- [MySQL Feature Support on RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.FeatureSupport.html)
+- [Aurora MySQL v2 vs MySQL 5.7](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.CompareMySQL57.html)
+- [Aurora MySQL v3 (MySQL 8.0)](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.MySQL80.html)
+- [Master User Account Privileges](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.MasterAccounts.html)
+- [RDS Quotas and Constraints](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html)
+- [Aurora MySQL Security](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Security.html)
+- [Aurora PostgreSQL Extensions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Extensions.html)
+- [RDS PostgreSQL Common DBA Tasks](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html)
+- [Aurora MySQL Migration Prechecks](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.ExtMySQL.Prechecks.html)
+- [RDS Storage Types](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html)
+- [Aurora Maintenance](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.Maintenance.html)
+- [Trusted Language Extensions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL_trusted_language_extension.html)
+
+---
+
+*Document generated from AWS official documentation. Last verified: May 2026. Always check current AWS documentation for the latest information as features are regularly added.*

--- a/db-migration-agent-skill/shared/reference/regulatory-compliance.md
+++ b/db-migration-agent-skill/shared/reference/regulatory-compliance.md
@@ -1,0 +1,114 @@
+# Korean Compliance & Regulatory Requirements for DB Migration to AWS
+
+> **Critical Reference Document** — Why Korean enterprises encrypt, audit, and network-separate their databases, and exactly how each requirement maps onto an RDS/Aurora landing zone. These rules are the *reason* the third-party tools in [third-party-db-security.md](third-party-db-security.md) exist; the AWS-native controls here are how you satisfy the same rules after migration.
+
+> **Confidence labels**: claims marked **[Regulatory]** are well-established regulatory facts whose verbatim primary text (KISA/PIPC standards) should be re-confirmed against the current " " before publishing a customer plan. Framework-level claims are cited to authoritative legal/AWS sources.
+
+---
+
+## 1. PIPA — Personal Information Protection Act (Korea)
+
+PIPA requires controllers to take technical/administrative/physical safeguards against loss, theft, leakage, alteration, or destruction of personal information. Concretely the law and its subordinate "Standards for Safety Measures" require: an internal control plan, **access-control devices (intrusion-blocking systems)**, measures to **prevent fabrication/alteration of access (log) records**, **encryption** for safe storage and transmission, and anti-malware controls.
+
+### 1.1 Encryption is a statutory obligation
+
+- **PIPA Article 24(3)** restricts handling of *unique identifying information* and requires "necessary measures … **including encryption**."
+- The **Enforcement Decree** requires resident registration numbers to be **retained encrypted at rest**, regardless of controller size.
+
+**Fields that must be encrypted** **[Regulatory]**:
+
+| Field | Requirement |
+|-------|-------------|
+| (RRN) and other (passport #, driver's license #, foreigner reg. #) | Encrypted at rest **and** in transit |
+| (passwords) | **One-way (irreversible)** encryption — hashing, not decryptable |
+| (biometric data) | Encrypted |
+| / (card / bank account numbers) | Encrypted |
+
+**Algorithm guidance** **[Regulatory]**: KISA recognizes domestic and international symmetric block ciphers — **SEED, ARIA (Korean national standards), and AES** — for reversible encryption, and one-way functions in the **SHA-256 or stronger** family for passwords.
+
+### 1.2 Access-log retention **[Regulatory]**
+
+- Baseline: retain access/processing records for **at least 1 year**.
+- Extended: **at least 2 years** for larger controllers (commonly: ≥1,000,000 data subjects, or handling unique-identifying/sensitive info, or telecom/financial controllers).
+- Logs must be protected from alteration.
+
+### 1.3 Current dates worth flagging to customers
+
+- PIPC issued updated **Guidelines on Security Standards on 31 Oct 2024**.
+- Major **PIPA amendments take effect 11 Sep 2026**.
+- **ISMS-P certification becomes mandatory, enforced from 1 Jul 2027** for in-scope entities.
+
+### 1.4 RDS/Aurora design implications
+
+| PIPA requirement | RDS/Aurora control |
+|------------------|--------------------|
+| Encryption at rest | **RDS/Aurora KMS encryption** (AES-256). Enable at instance creation — cannot be added later. |
+| Encryption in transit | Force TLS: `rds.force_ssl=1` (PostgreSQL), `require_secure_transport=ON` (MySQL/Aurora MySQL). |
+| RRN / passwords / biometrics / account numbers | **Column-level**: passwords one-way hashed; sensitive fields app-side encrypted (AWS Encryption SDK + KMS, or vendor API mode supporting SEED/ARIA). KMS-at-rest alone does **not** satisfy a SEED/ARIA *field* mandate. |
+| Access-control devices | RDS in **private subnets**, security groups, **IAM DB auth**, least-privilege roles, optional RDS Proxy / vendor gateway. |
+| Prevent alteration of access records | Ship audit logs (DAS → Kinesis → S3, or engine audit → CloudWatch → S3) with **S3 Object Lock** for immutability; retain **1 or 2 years** per §1.2. |
+| Audit logging | **Database Activity Streams** (separation of duties — DBAs can't touch the stream) + engine audit (`pgaudit`, MariaDB Audit Plugin, SQL Server Audit). |
+
+---
+
+## 2. Electronic Financial Supervision Regulation (FSC, Korea)
+
+For financial institutions, the FSC regime historically mandated **strict network separation (network separation (mangbunri))** between systems handling sensitive data and external networks, plus access control, encryption, audit logging, and separation of duties.
+
+### 2.1 The 2026 network-separation reform (directly relevant to cloud DB connectivity)
+
+- On **20 Jan 2026**, the **FSC/FSS announced an exemption from the network-separation rule for cloud-based SaaS** — removing the prior case-by-case regulatory-sandbox approval for back-office/administrative SaaS.
+- **The exemption explicitly excludes systems processing users' unique identification information or personal credit information** — those remain under full network-separation rules.
+- Compensating controls required: pre-screening by the **Financial Security Institute**, strict authentication and **least-privilege access**, **network-layer encryption**, monitoring of critical information flows, and **semi-annual (6-month) compliance audits**.
+
+**Implication for the migration plan:** A core banking / credit-data DB does **not** benefit from the SaaS exemption — plan it for the **stricter separated regime**. The reform mainly eases adoption of managed tooling for *non-sensitive* workloads.
+
+---
+
+## 3. Network Separation (mangbunri)
+
+**What it is**: separation between internal systems handling sensitive data and external/internet-facing networks — physical or logical separation of terminals and information-processing systems (servers). Rooted in the Electronic Financial Transactions Act / financial supervisory regulations (origins ~2014).
+
+### 3.1 Effect on connecting to RDS/Aurora — VPC design
+
+- **Private subnets only** for RDS/Aurora (`PubliclyAccessible = false`). This is the de-facto way to honor data-tier/internet separation.
+- **Private connectivity** for app→DB and admin→DB: within the VPC, across VPC peering / Transit Gateway, or from on-prem via **Direct Connect / Site-to-Site VPN**. **No internet egress from the DB tier.**
+- **AWS service access via VPC endpoints / PrivateLink** (Secrets Manager, KMS, S3, monitoring) so the DB tier never needs an internet/NAT path.
+- **Admin/operations segment**: DBA access via **SSM Session Manager** (no public bastion). Conceptually reproduces the internal/external separation inside AWS.
+- For workloads still under full separation: an **isolated VPC with no internet gateway**, endpoint-only AWS access, and tightly CIDR-restricted security groups.
+
+---
+
+## 4. ISMS-P Certification
+
+ISMS-P (Information Security Management System + Personal information protection) is Korea's combined security/privacy certification, **mandatory and enforced from 1 Jul 2027** for in-scope entities. DB-relevant controls track the PIPA Safety Measures:
+
+| ISMS-P control area | RDS/Aurora evidence |
+|---------------------|---------------------|
+| Access control (authentication, least privilege, RRN/admin access restriction) | IAM DB auth, least-privilege roles, RDS Proxy/vendor gateway, security groups |
+| Encryption (at rest + in transit) of personal/unique data | KMS at-rest + TLS in-transit + app-side column encryption |
+| Audit-log retention (1/2-year access-record rule) | DAS/engine audit → Kinesis/CloudWatch → S3 (Object Lock), retention configured |
+
+**[Regulatory]** Exact ISMS-P control IDs should be confirmed against the current catalog before a certification engagement.
+
+---
+
+## 5. Compliance → Migration-Task Mapping (drop into the plan)
+
+| Requirement | Prerequisite / migration task |
+|-------------|-------------------------------|
+| Encryption at rest | Create RDS/Aurora **with KMS encryption enabled** (cannot retrofit — must be a creation-time task). |
+| In-transit encryption | Set `force_ssl` / `require_secure_transport`; update app connection strings to require TLS. |
+| Field-level (RRN/account/biometric) | Confirm vendor API-mode availability **or** implement AWS Encryption SDK + KMS; if SEED/ARIA mandated, vendor API mode. |
+| Passwords | Verify one-way hashing in the app; never reversibly encrypt. |
+| Audit trail + immutability | Enable **DAS**; route to S3 with **Object Lock**; set retention to **1 or 2 years**; wire to SIEM/vendor. |
+| network separation (mangbunri) / financial sensitivity | Private subnets, no IGW for DB tier, PrivateLink endpoints, Direct Connect/VPN for on-prem; document separation in the To-Be architecture Compliance Matrix. |
+| Certification timeline | Note PIPA 2026-09-11 and ISMS-P 2027-07-01 dates if the customer's go-live is near them. |
+
+---
+
+## 6. Honesty / Confidence Notes
+
+- The regulatory **framework** (PIPA Art. 24(3) encryption mandate, network separation, ISMS-P timing, the 2026 FSC reform) is firmly attributable to authoritative legal sources.
+- The **granular KISA specifics** (exact SEED/ARIA/AES/SHA-256 algorithm table and the precise 1-vs-2-year retention thresholds) are well-established but should be **verified against the current " "** before being stated as fact to a customer.
+- Regulations change. This reflects research as of **2026-06**; re-verify dates and thresholds before publishing.

--- a/db-migration-agent-skill/shared/reference/source-assessment.md
+++ b/db-migration-agent-skill/shared/reference/source-assessment.md
@@ -1,0 +1,349 @@
+# Source Assessment — Scope, Compatibility Blockers, Sizing, Access Paths
+
+> Read this during **Phase 2 (Assess)**. It covers: engine scope, the blocker/adjustment
+> catalog with assessment queries (MySQL/MariaDB/PostgreSQL/Oracle/SQL Server), how to
+> physically reach a private-subnet source, credential-handling rules, sizing queries,
+> throughput estimation, and the offline-seed (Snow/DataSync) branch.
+> Full per-limitation detail: [rds-aurora-limitations.md](rds-aurora-limitations.md).
+
+## Scope & Coverage (Read First)
+
+**Engines covered.** This skill covers migration to **all RDS/Aurora engines**: MySQL, MariaDB, PostgreSQL, Oracle, SQL Server, Db2, Aurora MySQL, Aurora PostgreSQL.
+
+- **Homogeneous** (same engine family, e.g. EC2 MySQL → Aurora MySQL, **Oracle → RDS Oracle, SQL Server → RDS SQL Server**): the native-tool fast paths (see method-selection.md and execution-runbooks.md). DMS is *not* the default. Oracle and SQL Server lift-and-shift have **dedicated native paths** — Oracle Data Pump ([execution-runbooks.md](execution-runbooks.md) §"Oracle Data Pump") and SQL Server native backup/restore via S3 (execution-runbooks.md §"SQL Server Native Backup/Restore"). The matrix in [method-selection.md](method-selection.md) covers them.
+- **Heterogeneous** (Oracle/SQL Server → **Aurora/PostgreSQL/MySQL**, i.e. the engine family *changes*): requires schema/code conversion. See **[heterogeneous-migration.md](heterogeneous-migration.md)** — SCT / DMS Schema Conversion / Babelfish, PL/SQL→PL/pgSQL challenges, license implications. **Oracle → RDS Oracle and SQL Server → RDS SQL Server are NOT heterogeneous** — stay in this skill.
+- **Korean-market source engines** (Tibero, CUBRID, Altibase): **no native AWS DMS/SCT tooling** — PoC + JDBC paths. See heterogeneous-migration.md §5.
+
+**Korean enterprise scenarios (CHECK EARLY).** Korean enterprises almost always wrap the DB in a domestic **access-control/audit appliance** (Chakra Max, DBSafer, Petra) and a **DB encryption** product (Petra Cipher, D'Amo, CUBE-One). These break on managed RDS in their sniffing/agent/plug-in modes and are the **#1 cause of stalled migrations**. Before choosing a method, read **[third-party-db-security.md](third-party-db-security.md)** and **[regulatory-compliance.md](regulatory-compliance.md)** (PIPA encryption mandates, network separation (mangbunri), ISMS-P, audit-log retention). The rule: **access control → vendor gateway mode in the VPC + Database Activity Streams; encryption → vendor API mode or KMS at-rest + app-side column encryption.**
+
+> **Downtime expectation.** For EC2 → RDS/Aurora migrations, this skill targets a **10–30 second write-pause** at cutover (app restart or connection-pool refresh). True zero-downtime (0 lost requests) isn't achievable on this path without an intermediary proxy already in place — the skill optimizes for the *shortest* pause via CDC catch-up + coordinated cutover. To minimize further: pre-set connection-pool `maxLifetime` to 30s; prefer a coordinated app restart over Secrets Manager rotation (≈10s vs up to 5 min for pool TTL); deploy RDS Proxy on the **target** so future failovers are sub-second even though the initial cutover still pauses briefly. Blue/Green (< 1s with RDS Proxy) needs the source *already* on RDS — it applies to RDS→Aurora upgrades, not initial EC2→RDS moves. See cutover-procedures.md §"Minimize the Write-Pause Window".
+
+---
+
+## Compatibility Assessment (CRITICAL — Do First)
+
+Before choosing a migration method or target, assess whether the source workload is COMPATIBLE with managed services. The following are common **blockers** and **adjustments** that must be resolved first.
+
+### 1.1 Blockers — Must Resolve Before Migration
+
+| Category | Blocker | Impact | Resolution |
+|----------|---------|--------|------------|
+| **Encryption** | MySQL TDE (Transparent Data Encryption) enabled | Data encrypted at tablespace level won't transfer | Decrypt before migration → re-encrypt with AWS KMS at rest |
+| **Encryption** | Keyring plugins (keyring_file, keyring_aws for MySQL) | Plugin not available on RDS/Aurora | Decrypt → use AWS KMS volume encryption instead |
+| **Encryption** | Third-party agents (Vormetric, Thales CipherTrust) | Host-level encryption agents can't run on managed instances | Remove agent → use AWS KMS + column-level app encryption |
+| **Encryption (KR)** | Korean DB encryption in **plug-in / OS-volume mode** (Petra Cipher plug-in, D'Amo DE/KE, CUBE-One) | Engine plug-ins and OS-volume agents can't run on managed RDS | Switch to vendor **API/app-side mode**, or KMS at-rest + app-side column encryption (SEED/ARIA at app layer if mandated). See `third-party-db-security.md` |
+| **Access control (KR)** | Korean DB access/audit in **sniffing or host-agent mode** (Chakra Max, DBSafer agent, Petra sniffing) | No SPAN/port-mirror and no OS access on managed RDS | Move to vendor **gateway/proxy mode** in the VPC + **Database Activity Streams** for audit. See `third-party-db-security.md` |
+| **Storage Engine** | MyISAM tables (Aurora target) | Aurora is InnoDB-only | Convert: `ALTER TABLE t ENGINE=InnoDB` before migration |
+| **Storage Engine** | FEDERATED engine | Not supported on RDS or Aurora | Redesign as application-level cross-DB queries |
+| **Storage Engine** | Custom engines (TokuDB, RocksDB, Spider) | Not available on managed services | Convert to InnoDB |
+| **Auth** | PAM / LDAP authentication plugins | Not supported | Switch to native auth, IAM DB auth, or Kerberos (AD) |
+| **Auth** | Custom auth plugins | Not loadable | Switch to native password or IAM auth |
+| **Features** | C-compiled UDFs (User Defined Functions) | Cannot install custom .so files | Rewrite as stored functions or move logic to app layer |
+| **Features** | Galera Cluster / Group Replication topology | Not available on Aurora | Redesign using Aurora Multi-AZ + read replicas |
+| **PostgreSQL** | C-language extensions (custom compiled) | Cannot install on Aurora | Check `pg_available_extensions`; rewrite or remove |
+| **PostgreSQL** | Direct pg_hba.conf access | No filesystem access | Use RDS security groups + IAM auth + SSL settings |
+| **Compressed tables** | InnoDB compressed row_format (Aurora) | Not supported on Aurora | `ALTER TABLE t ROW_FORMAT=DYNAMIC` before migration |
+
+### 1.2 Adjustments — Require Changes But Not Blocking
+
+| Category | Issue | What Happens | Workaround |
+|----------|-------|-------------|------------|
+| **Privileges** | Code uses SUPER privilege | Will fail on RDS/Aurora | Use `rds_superuser_role` (RDS) or session-level alternatives |
+| **Privileges** | DEFINER clauses in stored procs/views | Fails if definer user doesn't exist | Strip DEFINER or recreate user on target |
+| **File I/O** | `LOAD DATA INFILE` (server-side) | Blocked on RDS/Aurora | Use `LOAD DATA LOCAL INFILE` (client-side) or S3 import |
+| **File I/O** | `SELECT INTO OUTFILE` | Blocked | Use `SELECT ... INTO` with S3 (Aurora) or client-side export |
+| **Replication** | Multi-source replication | Only on RDS MySQL 8.0.35+, NOT Aurora | Redesign consolidation approach |
+| **Charset** | `lower_case_table_names` set to 2 | Not supported on Linux-based RDS/Aurora | Must be 0 (case-sensitive) or 1 (lowercase) |
+| **Timezone** | Non-UTC timezone_data differences | Can corrupt TIMESTAMP columns during migration | Set `time_zone` parameter explicitly on target |
+| **Versions** | MySQL 5.6 or earlier | Cannot migrate directly to Aurora MySQL 3.x (8.0) | Upgrade to 5.7 first, then migrate |
+| **OS** | Cron jobs / shell scripts on DB host | No OS access on managed | Move to EventBridge Scheduler, Lambda, or ECS tasks |
+
+### 1.3 Assessment Queries
+
+**Check for TDE (MySQL):**
+```sql
+SELECT * FROM information_schema.INNODB_TABLESPACES WHERE ENCRYPTION = 'Y';
+SHOW VARIABLES LIKE 'early-plugin-load';  -- keyring plugin loaded?
+```
+
+**Check storage engines (MySQL/MariaDB):**
+```sql
+SELECT TABLE_NAME, ENGINE FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = 'your_db' AND ENGINE != 'InnoDB';
+```
+
+**Check compressed tables (Aurora blocker):**
+```sql
+SELECT TABLE_NAME, ROW_FORMAT FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = 'your_db' AND ROW_FORMAT = 'Compressed';
+```
+
+**Check auth plugins:**
+```sql
+SELECT user, host, plugin FROM mysql.user WHERE plugin NOT IN ('mysql_native_password', 'caching_sha2_password');
+```
+
+**Check DEFINER clauses:**
+```sql
+SELECT ROUTINE_NAME, DEFINER FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = 'your_db';
+SELECT TABLE_NAME, DEFINER FROM information_schema.VIEWS WHERE TABLE_SCHEMA = 'your_db';
+```
+
+**Check UDFs:**
+```sql
+SELECT * FROM mysql.func;  -- Lists all installed UDFs
+```
+
+**Check PostgreSQL extensions:**
+```sql
+SELECT extname, extversion FROM pg_extension;
+-- Compare against Aurora's available extensions:
+SELECT name FROM pg_available_extensions ORDER BY name;
+```
+
+### 1.4 Oracle → RDS for Oracle — Blockers & Compatibility Checks
+
+RDS for Oracle is managed: **no OS/SSH, no RAC, no ASM (EBS-backed), no SYS/SYSDBA, no custom patches.** The master user gets the `DBA` role **minus** `ALTER DATABASE`, `ALTER SYSTEM`, `CREATE ANY DIRECTORY`, `DROP ANY DIRECTORY`, `GRANT ANY PRIVILEGE`, `GRANT ANY ROLE` — admin tasks go through `rdsadmin` packages and parameter groups instead. Assess these before choosing a method:
+
+| Category | Blocker / Adjustment | Impact | Resolution |
+|----------|----------------------|--------|------------|
+| **Engine version** | Only **19c and 21c** are supported/creatable on managed RDS. 10.2 / 11g / 12c / 18c are gone. | Cannot land on managed RDS | Upgrade to 19c+ first, or use **RDS Custom for Oracle** (BYOL/EE; note end-of-support 2027-03-31) / EC2 for deprecated majors. |
+| **Edition / licensing** | License Included = **SE2 only**; Enterprise Edition = **BYOL only**. SE2 caps at 16 vCPU / 128 GiB, no Data Guard / read replicas. | Wrong target edition blocks creation | Decide LI-SE2 vs BYOL-EE up front; EE features (TDE, partitioning options) need BYOL-EE. |
+| **Character set** | DB character set + NCHAR set are **fixed at instance creation, cannot change after**. CDB DB charset is always `AL32UTF8` (set non-default only on the PDB). | Mismatch corrupts data, unfixable post-create except recreate | Match target `--character-set-name` / `--nchar-character-set-name` to source (or proper superset) **before** loading. e.g. `KO16MSWIN949` for legacy Korean. |
+| **Architecture** | RAC topology / ASM storage | Not available | Redesign as single-instance + Multi-AZ; storage is EBS, no ASM tuning. |
+| **Disallowed import modes** | Data Pump **FULL mode** import; importing SYS/SYSTEM/RDSADMIN-owned objects (incl. Scheduler objects) | Can damage the data dictionary; unsupported | Use **schema or table mode** only; `EXCLUDE` system Scheduler objects (see execution-runbooks.md). |
+| **Transportable tablespaces import** | Dump files made with `TRANSPORT_TABLESPACES`/`TRANSPORTABLE`/`TRANSPORT_FULL_CHECK` via the *regular* impdp path | Not supported on the standard path | Use the dedicated `rdsadmin.rdsadmin_transport_util` XTTS path (EE-only — see method-selection.md). |
+| **TDE wallet** | Customer-managed Oracle Wallet | Cannot import your own wallet into managed RDS | RDS manages the wallet/master key. Export with Data Pump `ENCRYPTION_MODE=PASSWORD` (TRANSPARENT mode unsupported), import into a TDE-enabled target whose wallet AWS generates. See §1.4 checks below. |
+| **OS-file dependencies** | BFILE, external tables, `UTL_FILE`, FTP/SFTP, Messaging Gateway, Oracle Text File/URL datastores | No general filesystem; several features unsupported | Re-stage through RDS-managed directories (`DATA_PUMP_DIR` via S3); rework BFILE/external tables; Text must use non-File/URL datastores. |
+| **Unsupported features** | Data Guard, Database Vault, Flashback Database, RAS, Unified Auditing Pure Mode, Workspace Manager (WMSYS), hybrid partitioned tables, OEM repository | Won't migrate | Inventory dependencies; redesign or drop. Data Guard target → EC2/RDS Custom only. |
+| **File/block limits** | 16 TiB per single file (ext4); `DB_BLOCK_SIZE` fixed at creation; up to ~64 TiB instance storage | Large bigfile datafiles / block-size changes blocked | Plan tablespace layout; set block size at creation. |
+
+**Oracle pre-migration inventory queries** (run on source, resolve before migrating):
+```sql
+-- Directory objects (master user can't CREATE ANY DIRECTORY on RDS)
+SELECT owner, directory_name, directory_path FROM dba_directories;
+-- External tables (depend on directory objects / OS files)
+SELECT owner, table_name, default_directory_name FROM dba_external_tables;
+-- Network/file ACL-dependent packages (UTL_HTTP/SMTP/TCP need re-granted ACLs + VPC egress)
+SELECT * FROM dba_network_acls;
+-- Database links (recreate; need VPC routing + SG rules)
+SELECT owner, db_link, host FROM dba_db_links;
+-- Scheduler jobs (recreate app-owned; never import SYS/SYSTEM-owned)
+SELECT owner, job_name, schedule_type FROM dba_scheduler_jobs WHERE owner NOT IN ('SYS','SYSTEM','RDSADMIN');
+-- Java in the DB
+SELECT owner, COUNT(*) FROM dba_objects WHERE object_type LIKE 'JAVA%' GROUP BY owner;
+-- TDE in use at source?
+SELECT * FROM v$encryption_wallet;
+SELECT tablespace_name, encrypted FROM dba_tablespaces WHERE encrypted='YES';
+```
+
+### 1.5 SQL Server → RDS for SQL Server — Blockers & Compatibility Checks
+
+RDS for SQL Server is managed: **no OS/RDP, no `sysadmin` server role, no `RESTORE FROM DISK`.** The master user belongs only to `processadmin`, `public`, `setupadmin`; a DB creator gets `db_owner`. The file-based migration path is **native backup/restore via S3** (execution-runbooks.md). Assess:
+
+| Category | Blocker / Adjustment | Impact | Resolution |
+|----------|----------------------|--------|------------|
+| **Engine version / restore direction** | Native restore accepts a `.bak` from an **equal-or-lower** engine version, **never higher**. Supported majors: 2016/2017/2019/2022. | Higher-version `.bak` won't restore | Pick target RDS engine version ≥ source. EOS versions (2014 and older) are auto-upgraded; can keep older DB `COMPATIBILITY_LEVEL`. |
+| **Edition / licensing** | License Included (Enterprise/Standard/Web/Express) or **BYOM** (Ent/Std/Developer) via License Mobility + active Software Assurance. Standard capped at 24 cores / 128 GB by MS limits. | Wrong edition blocks features | Choose edition for the features you need (TDE, Multi-AZ). |
+| **TDE edition gating** | TDE needs Enterprise on 2016/2017; **Standard or Enterprise** on 2019/2022. | TDE unavailable on Web/Express | Pick Standard+ / Enterprise. |
+| **Security model** | Code needing `sysadmin`, `xp_cmdshell`, `CONTROL SERVER`, `UNSAFE`/`EXTERNAL_ACCESS` assembly, `CREATE ENDPOINT`, server-level triggers, `TRUSTWORTHY` | Roles/permissions not grantable on RDS | Refactor; move logic out of DB; CLR `SAFE` only on ≤2016, **not supported 2017+**. |
+| **FILESTREAM** | `.bak` containing a FILESTREAM filegroup | Native restore rejects it | Remove FILESTREAM/FileTable; redesign as BLOB columns or S3. |
+| **Unsupported features** | Log Shipping, Replication (as publisher/distributor), Maintenance Plans, Service Broker cross-instance endpoints, MSDTC/distributed transactions, PolyBase, Stretch DB, ML/R Services, backup to Azure Blob | Won't migrate | Emulate log shipping via native full+diff+log restores; recreate jobs; cross-instance messaging won't work. |
+| **Server-level objects** | Logins, SQL Agent jobs, linked servers live in `master`/`msdb` — **not** carried by a user-DB `.bak` (can't import `msdb`) | Orphaned users + missing jobs after restore | Script logins (preserve SID + HASHED password), Agent jobs, and linked servers separately; recreate on RDS. See execution-runbooks.md §"SQL Server — Server-Level Objects". |
+| **Max databases / Multi-AZ** | Per-instance DB limit depends on instance class + AZ mode; Multi-AZ native restore requires **FULL recovery model**; no native log *backups* from RDS | Restore/convert fails if over limit | Check the per-class limit before sizing; keep source in FULL recovery for minimal-downtime restores. |
+| **Collation** | Instance/server default collation set at creation | Server-level collation can't change later | Match instance collation to source; DB/column collations ride in the `.bak`. |
+
+**SQL Server pre-migration inventory queries** (run on source):
+```sql
+-- Recovery model (must be FULL for Multi-AZ native restore / log restores)
+SELECT name, recovery_model_desc FROM sys.databases;
+-- FILESTREAM filegroups (blocker for native restore)
+SELECT DB_NAME(database_id) db, type_desc, name FROM sys.master_files WHERE type_desc='FILESTREAM';
+-- CLR assemblies (unsupported 2017+)
+SELECT name, permission_set_desc FROM sys.assemblies WHERE is_user_defined=1;
+-- Logins to recreate on RDS (SID + hash preserved later — see execution-runbooks.md)
+SELECT name, type_desc FROM sys.server_principals WHERE type IN ('S','U','G') AND name NOT LIKE '##%##';
+-- SQL Agent jobs to recreate
+SELECT name, enabled FROM msdb.dbo.sysjobs;
+-- Linked servers to recreate
+SELECT name, product, provider FROM sys.servers WHERE is_linked=1;
+-- TDE-encrypted DBs (need certificate migration — see execution-runbooks.md §TDE)
+SELECT DB_NAME(database_id) db, encryption_state FROM sys.dm_database_encryption_keys;
+```
+
+---
+
+## Third-Party Tool Interference Sweep (ALWAYS run — every engine, every engagement)
+
+Real databases are almost never bare: security, backup, monitoring, HA, and proxy tools
+attach to the host or sit in front of the port — and each is a migration dependency that
+breaks differently on managed RDS (no OS access, no agents, no SPAN port). Customers
+usually forget these exist until asked (discovery Q17), so **detect, don't just ask**:
+
+```bash
+# On the DB host (via SSM): one sweep catches most agent categories
+ps -eo comm,args | grep -viE "^\[|mysqld|postgres|sqlservr" | sort -u | head -40
+systemctl list-units --type=service --state=running --no-pager | grep -viE "mysql|postgres|mssql|ssm|amazon|systemd|dbus|cron|network"
+dpkg -l 2>/dev/null | grep -iE "veeam|commvault|netbackup|datadog|newrelic|zabbix|nagios|guardium|imperva|proxysql|pgbouncer|maxscale|sios|pacemaker" \
+  || rpm -qa 2>/dev/null | grep -iE "veeam|commvault|netbackup|datadog|newrelic|zabbix|guardium|proxysql|pgbouncer|maxscale"
+ss -tnp | awk '$5 ~ /:3306|:5432|:1433|:1521/' | head -20   # who proxies/monitors the port locally?
+```
+
+| Category | Examples | What breaks on managed RDS | Disposition |
+|----------|----------|---------------------------|-------------|
+| **DB security / audit / encryption** | Chakra Max, DBSafer, Petra (KR); Guardium, Imperva, Thales/Vormetric (global) | Sniffing / host-agent / engine-plug-in / OS-volume modes all die (no OS, no SPAN) | Full playbook: [third-party-db-security.md](third-party-db-security.md) — gateway/API modes survive; DAS/KMS replace the rest |
+| **Backup agents** | Veeam, Commvault, NetBackup, custom dump scripts | Host agents can't install on RDS; local dump scripts die with the host | Retire in favor of RDS automated backups / AWS Backup; verify the customer's retention policy is met BEFORE decommission — the agent's catalog may be the only long-term archive |
+| **Monitoring agents** | Datadog/New Relic/Zabbix DB plugins, Prometheus exporters on-host | On-host collectors gone; some checks (filesystem, replication internals) have no RDS equivalent | Repoint to endpoint-based checks + CloudWatch/Performance Insights integrations; map each dashboard/alert to its replacement in the plan |
+| **HA / clusterware** | Galera (already a blocker), SIOS, Pacemaker/heartbeat, keepalived VIPs | Whole topology replaced by Multi-AZ/Aurora; a VIP the app points at is a hidden client-repoint target | Decommission with the cluster; if the app connects to a VIP, that VIP is a Phase 7.5 inventory row |
+| **Connection proxies / poolers** | ProxySQL, PgBouncer, MaxScale, HAProxy (on host or in front) | The proxy is BOTH a client (repoint its backend) and topology (apps point at it, not the DB) | Decide: keep the proxy and repoint its backend at cutover (often the cheapest cutover of all), or retire it for RDS Proxy — either way it gets inventory rows on both sides |
+
+Every hit → a row in `migration-plan.md` (finding + disposition + owner). A tool you
+found here will reappear in Phase 7.5 (as a client) or Phase 9 (as a decommission item) —
+cross-reference the rows.
+
+## Source Database Assessment
+
+### Execution Location — How Will You Reach the Source DB? (Decide First)
+
+The source DB is almost always in a **private subnet**, and your execution environment (laptop, CloudShell, an automation runner, this skill's host) is frequently **in a different VPC or has no `mysql`/`psql` client installed**. Settle the access path *before* running any assessment query — it determines how every assessment, dump, and cutover command in this skill is invoked.
+
+| Option | When | How |
+|--------|------|-----|
+| **Direct** | Execution host is in the **same VPC/subnet** and has a client installed | Standard `mysql -h <db> …` / `psql` |
+| **Bastion (SSH tunnel)** | A bastion host exists in the DB's VPC | `ssh -L 3306:<db-endpoint>:3306 ec2-user@bastion` then connect to `127.0.0.1:3306` |
+| **SSM Port Forwarding** | DB host (or a host in-VPC) is an SSM-managed instance; you have a local client | `aws ssm start-session --target <instance-id> --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"host":["<db-endpoint>"],"portNumber":["3306"],"localPortNumber":["13306"]}'` then connect to `127.0.0.1:13306` |
+| **SSM Send-Command** | **No local client / cross-VPC** — run the query *on the DB host itself* (or another in-VPC SSM-managed host that has a client) | `aws ssm send-command --instance-ids <id> --document-name AWS-RunShellScript --parameters 'commands=["mysql -h 127.0.0.1 -e \"…\""]'` |
+
+> **Default recommendation for an isolated/private-subnet source: SSM.** Port forwarding when you have a local client; **Send-Command when you don't** (run the client that already exists on the DB host). This avoids opening the DB to new networks just to migrate it. The same path is reused for the `mysqldump`/`pg_dump` export (execution-runbooks.md) and the processlist cross-checks (cutover-procedures.md).
+
+### Credential Handling — Never Put Passwords in `argv`
+
+Every command below (assessment, dump, cutover) needs DB credentials. **Passwords in command-line arguments are visible in `ps -ef`, shell history, and — when run via SSM/SSH — in CloudTrail and SSM command history.** Rules:
+
+- **Never** pass `-p<password>` or `--password=<pw>` on the command line.
+- Use **`MYSQL_PWD`** env var (`export MYSQL_PWD=...; mysql -h … -u …`) or a **`--defaults-extra-file`** with `[client] password=...` (chmod 600).
+- **Preferred:** fetch the secret **on the DB host** using the instance's IAM role, so the plaintext never transits your machine or appears in argv:
+  ```bash
+  # Run on the DB host (e.g. via SSM Send-Command); password stays on the host, out of argv
+  export MYSQL_PWD=$(aws secretsmanager get-secret-value \
+    --secret-id ecommerce-demo/db-credentials --query SecretString --output text \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["password"])')
+  mysql -h 127.0.0.1 -u admin -e "SELECT VERSION();"
+  ```
+- PostgreSQL: use `PGPASSWORD` or a `~/.pgpass` (chmod 600) the same way.
+
+### Information to Collect
+
+| Category | What | How |
+|----------|------|-----|
+| Engine & version | MySQL 5.7/8.0, MariaDB 10.x, PostgreSQL 12-16 | `SELECT VERSION();` |
+| Total size | Data + indexes in GB | See queries below |
+| Table count | Number of tables, top 10 largest | `information_schema.tables` |
+| Schema objects | Stored procs, triggers, views, events, functions | `information_schema.routines`, `pg_proc` — **privileged account required, see warning below** |
+| LOB columns | BLOB/TEXT/JSON columns, max sizes | Profile actual data sizes |
+| Replication readiness | Binary logging (MySQL) / wal_level (PostgreSQL) | `SHOW VARIABLES LIKE 'log_bin'` / `SHOW wal_level` |
+| Current connections | Typical/peak concurrent connections | `SHOW STATUS LIKE 'Threads_connected'` |
+| Source location | EC2 (same VPC? same region?), on-premises, other cloud? | User input |
+| **Network bandwidth** | Usable Mbps on the path source→AWS (Direct Connect / VPN / internet egress). Use the *usable* figure, not the link's rated speed. | User input / `iperf3` to an EC2 box in target region |
+| **Transfer window** | Hours of acceptable downtime (offline copy) *or* hours available for bulk load before CDC catch-up | User input |
+
+> ⚠️ **Schema-object inventory is privilege-filtered — a low-privilege account SILENTLY
+> UNDERCOUNTS.** `information_schema.routines` (MySQL/MariaDB) only shows routines the
+> current account can see; an app user without `SHOW ROUTINE`/definer visibility returns
+> an empty set even when procedures exist, and the plan then wrongly records "no schema
+> objects" — the classic way a target ships missing a stored procedure that nothing
+> notices until the first application call fails. Rules: (1) run the object inventory with a privileged account (root/definer-
+> visible or a migration user granted `SHOW ROUTINE` / `SELECT ON mysql.proc`-equivalent);
+> (2) **cross-check counts from two vantage points** — e.g. `SHOW PROCEDURE STATUS WHERE
+> Db='your_db'` as root (via SSM on-host) vs the same query as the assessment user — and
+> treat any mismatch as "inventory incomplete", never "no objects"; (3) PostgreSQL:
+> `pg_proc` visibility is schema/ACL-dependent — inventory as a superuser or table owner.
+
+### Sizing Queries
+
+**MySQL/MariaDB:**
+```sql
+SELECT table_schema,
+  ROUND(SUM(data_length + index_length) / 1024 / 1024 / 1024, 2) AS size_gb,
+  COUNT(*) AS table_count
+FROM information_schema.tables
+WHERE table_schema = 'your_db'
+GROUP BY table_schema;
+```
+
+**PostgreSQL:**
+```sql
+SELECT pg_size_pretty(pg_database_size('your_db')) AS db_size;
+SELECT count(*) AS table_count FROM pg_tables WHERE schemaname = 'public';
+```
+
+**Oracle:**
+```sql
+-- Total DB size (datafiles + temp)
+SELECT ROUND(SUM(bytes)/1024/1024/1024, 2) AS size_gb FROM dba_segments;
+-- Per-schema size + object counts
+SELECT owner, ROUND(SUM(bytes)/1024/1024/1024,2) AS size_gb
+FROM dba_segments WHERE owner NOT IN ('SYS','SYSTEM','RDSADMIN') GROUP BY owner;
+SELECT owner, object_type, COUNT(*) FROM dba_objects
+WHERE owner NOT IN ('SYS','SYSTEM','RDSADMIN') GROUP BY owner, object_type ORDER BY 1,2;
+```
+
+**SQL Server:**
+```sql
+-- Per-DB size
+SELECT DB_NAME(database_id) AS db, SUM(size)*8/1024 AS size_mb FROM sys.master_files GROUP BY database_id;
+-- Object counts + per-table rows (run in the target DB context)
+SELECT type_desc, COUNT(*) FROM sys.objects GROUP BY type_desc ORDER BY type_desc;
+```
+
+### Throughput Estimation (run BEFORE choosing a method)
+
+A method is only viable if the bulk data can physically move within the transfer window.
+Estimate the over-the-wire transfer time from DB size and usable bandwidth:
+
+```
+estimated_hours = db_size_gb / (bandwidth_mbps * 0.125 * 0.7)
+```
+
+- `* 0.125` converts Mbps → MB/s (8 bits per byte).
+- `* 0.7` is a 70% real-world efficiency factor (TCP overhead, encryption, contention, restart
+  retries). For a clean same-region 10 GbE path you can use 0.8; for busy shared internet egress
+  use 0.5.
+
+**Worked examples** (usable bandwidth, not rated link speed):
+
+| DB size | Usable bandwidth | Estimated transfer | Implication |
+|---------|------------------|--------------------|-------------|
+| 50 GB | 1 Gbps (≈940 Mbps usable) | ~0.2 hr (~12 min) | Online copy trivially fits any window |
+| 500 GB | 200 Mbps (typical site VPN) | ~10 hr | Needs an overnight window or CDC catch-up |
+| 2 TB | 200 Mbps | ~40 hr | Wire transfer infeasible in a normal window → **Snow Family** |
+| 2 TB | 1 Gbps Direct Connect | ~8 hr | Feasible with DX + CDC; without DX, use Snow |
+| 10 TB | 500 Mbps | ~127 hr (>5 days) | **Snow Family mandatory** |
+
+**Decision rule:**
+
+1. Compute `estimated_hours`.
+2. If `estimated_hours` ≤ transfer window → online method (dump/restore, XtraBackup+S3, DMS) is fine.
+3. If `estimated_hours` > transfer window **and** source is on-prem/other-cloud **and** size > 1 TB
+   → **flag it** and route to the offline-seed branch below. Do not silently pick a method that
+   can't finish in time.
+4. If only modestly over window → DMS Full Load + CDC: the bulk full-load can run for days while
+   the app stays up, and CDC closes the gap — the *downtime* is just the final CDC drain, not the
+   whole transfer.
+
+### Offline-Seed Branch — Snow Family / DataSync (on-prem + low bandwidth + > 1 TB)
+
+When the wire can't carry the data in time, seed Aurora/RDS from a physical/offline copy, then
+catch up the delta with CDC:
+
+| Condition | Approach |
+|-----------|----------|
+| > 1 TB, on-prem, bandwidth-bound, hard cutover deadline | **AWS Snowball Edge**: export dump/XtraBackup to the device → ship to AWS → load into S3 → `restore-db-cluster-from-s3` (MySQL) or import → then **DMS CDC** from on-prem to close the delta accumulated since the export LSN/binlog position. |
+| 100 GB – 1 TB, on-prem, slow but no hard deadline | **AWS DataSync** over DX/VPN to land the dump in S3 (managed, resumable, checksummed), then restore + CDC catch-up. |
+| Continuous/repeated file sync from on-prem | **DataSync** scheduled tasks. |
+
+**Critical for Snow + CDC**: record the source's binlog file+position (MySQL) or LSN/replication
+slot (PostgreSQL) **at the moment the offline export is taken**, so the subsequent DMS CDC task
+starts exactly from that point. Mismatched start position = duplicate or missing rows.
+
+---

--- a/db-migration-agent-skill/shared/reference/target-provisioning.md
+++ b/db-migration-agent-skill/shared/reference/target-provisioning.md
@@ -1,0 +1,100 @@
+# Target Provisioning — Aurora vs RDS, Immutable Settings, RDS Proxy, TLS Gate
+
+> Read this during **Phase 4 (Provision Target)**. Wrong choices here are the #1 cause of
+> "recreate the whole instance" rework — several settings are fixed at creation.
+> CDK implementation of everything below: [../patterns/cdk-stacks.md](../patterns/cdk-stacks.md).
+
+---
+
+## Target Provisioning
+
+### Aurora vs RDS Selection
+
+| Factor | Aurora | RDS |
+|--------|--------|-----|
+| Availability | 99.99% (6 copies across 3 AZs) | 99.95% (Multi-AZ synchronous standby) |
+| Auto-scaling storage | ✅ Up to 128 TiB | ❌ Must provision EBS |
+| Read replicas | 15 (single reader endpoint) | 15 (individual endpoints) |
+| Failover time | < 30 seconds | 60-120 seconds |
+| Serverless option | ✅ Aurora Serverless v2 | ❌ |
+| Cost (minimum) | ~$60/mo (db.t4g.medium) | ~$13/mo (db.t4g.micro) |
+| Global Database | ✅ Cross-region < 1s lag | ❌ |
+| Backtrack (MySQL) | ✅ Point-in-time rewind | ❌ |
+
+### Instance Sizing During Migration
+
+Size LARGER during migration for import throughput, then scale down:
+
+| DB Size | Migration Instance | Steady-State Instance |
+|---------|-------------------|----------------------|
+| < 50 GB | db.r6g.large | db.r6g.medium or Serverless v2 |
+| 50-500 GB | db.r6g.xlarge | db.r6g.large |
+| 500 GB - 2 TB | db.r6g.2xlarge | db.r6g.xlarge |
+| > 2 TB | db.r6g.4xlarge | db.r6g.2xlarge |
+
+### Oracle / SQL Server Target Provisioning — Settings Fixed at Creation
+
+These cannot be changed after the instance is created — get them right up front (they're a frequent cause of "recreate the whole instance" rework):
+
+| Engine | Set-at-creation, immutable | CLI flag | Notes |
+|--------|----------------------------|----------|-------|
+| **RDS Oracle** | DB character set | `--character-set-name` | Default `AL32UTF8`. Match source (e.g. `KO16MSWIN949`). CDB DB charset is always `AL32UTF8` — set non-default on the PDB only. |
+| **RDS Oracle** | NCHAR character set | `--nchar-character-set-name` (CLI v2) | `AL16UTF16` (default) or `UTF8`. |
+| **RDS Oracle** | `DB_BLOCK_SIZE` | parameter group at create | Default 8 KB; cannot change later. |
+| **RDS Oracle** | Edition + license model | `--engine oracle-ee`/`oracle-se2`, `--license-model` | LI = SE2 only; EE = BYOL only. |
+| **RDS SQL Server** | Server/instance collation | `--collation` (via parameter or console) | DB/column collations ride in the `.bak`; the *instance* default can't change later. |
+| **RDS SQL Server** | Edition + license model | `--engine sqlserver-ee`/`-se`/`-web`/`-ex`, `--license-model` | License-Included or BYOM (License Mobility + Software Assurance). |
+
+**Option groups (required for the native paths):** RDS Oracle Data Pump via S3 needs the **`S3_INTEGRATION`** option + an IAM role on `S3_INTEGRATION`; RDS SQL Server native backup/restore needs the **`SQLSERVER_BACKUP_RESTORE`** option with an IAM role; TDE on either engine needs the **`TDE`** option (permanent + persistent — cannot be removed once attached). Set these on the option group before execution (Phase 6).
+
+### RDS Proxy on the Target (provision BEFORE cutover for minimal-downtime / future failover)
+
+For minimal-downtime workloads, stand up **RDS Proxy in front of the target cluster** during provisioning — before Phase 8 — so the app connects through the proxy endpoint from the moment of cutover. The proxy does **not** remove the brief *initial* EC2→RDS cutover pause, but once in place it makes every subsequent failover/maintenance event a **< 1s reconnect with no app restart and no pool refresh** (the proxy holds client connections and re-points to the new writer), and it absorbs the reconnect storm when the app's pool refreshes at cutover.
+
+```bash
+# Create a proxy targeting the new cluster; creds come from Secrets Manager (the same secret you rotate at cutover)
+aws rds create-db-proxy \
+  --db-proxy-name your-app-proxy \
+  --engine-family MYSQL \
+  --auth '[{"AuthScheme":"SECRETS","SecretArn":"arn:aws:secretsmanager:REGION:ACCT:secret:your-app/db-credentials","IAMAuth":"DISABLED"}]' \
+  --role-arn arn:aws:iam::ACCT:role/rds-proxy-secrets-role \
+  --vpc-subnet-ids subnet-aaa subnet-bbb \
+  --require-tls
+aws rds register-db-proxy-targets \
+  --db-proxy-name your-app-proxy \
+  --db-cluster-identifier your-aurora-cluster
+```
+
+Then point clients at the **proxy endpoint** (`your-app-proxy.proxy-xxxx.<region>.rds.amazonaws.com`) in Phase 7.5/8, not the cluster endpoint. PostgreSQL: use `--engine-family POSTGRESQL`. (RDS Proxy requires the target to be RDS/Aurora — it's a target-side construct, so it works for EC2→RDS even though the *source* can't be proxied.)
+
+### TLS-Enforcement Gate (check the target parameter group BEFORE loading or cutover)
+
+Compliance baselines (K-ISMS, PCI, internal hardening) commonly set **`require_secure_transport=ON`** (MySQL/MariaDB) or **`rds.force_ssl=1`** (PostgreSQL) on the target parameter group. When enforced, **every** connection must use TLS — and that breaks two things if you don't plan for it:
+
+1. **The migration load tool** — `mysqldump`/`mysql` import and `psql` restore must connect with TLS, or the import fails at connect time.
+2. **The application connector** — the app's JDBC/driver string must request TLS *and* must be a version that supports the parameter, or the app can't reconnect after cutover.
+
+**Check first:**
+```sql
+SHOW VARIABLES LIKE 'require_secure_transport';   -- MySQL/MariaDB: should be ON if enforced
+-- PostgreSQL: parameter rds.force_ssl = 1
+```
+Then verify both the load tool and the app connector are configured for TLS. Connector parameter reference:
+
+| Connector | TLS parameter |
+|-----------|---------------|
+| `mysql` / `mariadb` CLI | `--ssl` (optionally `--ssl-ca=rds-combined-ca-bundle.pem` to verify the server cert) |
+| Connector/J 8.x–9.x | `sslMode=REQUIRED` (use `VERIFY_CA` + `trustCertificateKeyStoreUrl` to validate the cert) |
+| Connector/J 5.1.x | `useSSL=true&requireSSL=true` |
+| Node `mysql2` | `ssl: { rejectUnauthorized: false }` (or `{ ca: fs.readFileSync('rds-combined-ca-bundle.pem') }` to verify) |
+| Python `mysqlclient` | `ssl={'ca': '/path/to/rds-combined-ca-bundle.pem'}` |
+| `psql` / libpq | `sslmode=require` (or `verify-ca` / `verify-full` with `sslrootcert=`) |
+
+> **RDS Proxy presents a different certificate chain than the cluster endpoints.** If the
+> app connects through a proxy endpoint with certificate verification on, validate the CA
+> bundle against the PROXY endpoint, not (only) the writer endpoint — use the combined
+> global `rds-combined-ca-bundle`/AmazonRootCA trust store — a CA bundle validated only
+> against the writer endpoint will abort the cutover at the proxy connection probe.
+
+> **Watch the default mismatch.** Connector/J ≥ 8.0.13 defaults to `sslMode=PREFERRED` — it *tries* TLS but **silently falls back to plaintext if the server allowed it**. With `require_secure_transport=ON` the server refuses plaintext, so PREFERRED can still connect — but make the intent explicit with `sslMode=REQUIRED` so behavior doesn't depend on negotiation. The `rds-combined-ca-bundle.pem` is downloadable from the AWS docs (region-specific bundles also available).
+

--- a/db-migration-agent-skill/shared/reference/third-party-db-security.md
+++ b/db-migration-agent-skill/shared/reference/third-party-db-security.md
@@ -1,0 +1,267 @@
+# Korean DB Security Tools vs. RDS/Aurora — Migration-Blocker Playbook
+
+> **Critical Reference Document** — Korean enterprises almost never run a bare database. They wrap it in a domestic **DB access-control / audit** appliance and a **DB encryption** product, both mandated in practice by PIPA, the Electronic Financial Supervision Regulation, and ISMS-P. These tools are the single most common reason a "simple" RDS/Aurora migration stalls. This document explains how each tool works, **what breaks when the OS and the network disappear under managed RDS**, and the AWS-native pattern that replaces it.
+
+> **Companion documents**: [regulatory-compliance.md](regulatory-compliance.md) (why these tools are deployed in the first place), [rds-aurora-limitations.md](rds-aurora-limitations.md) (engine-level blockers), [heterogeneous-migration.md](heterogeneous-migration.md) (Tibero/CUBRID/Altibase and Oracle/SQL Server paths).
+
+---
+
+> **Scope note:** this playbook applies to third-party DB *security* tooling anywhere —
+> the attachment-mode analysis below is vendor-agnostic (Guardium/Imperva/Thales are
+> covered under §Global Enterprise Tools). The deep per-product detail focuses on the
+> Korean market because those products dominate stalled migrations there. For the other
+> third-party categories (backup, monitoring, HA, proxies), see the interference sweep in
+> [source-assessment.md](source-assessment.md).
+
+## The core thesis (read this first)
+
+On a self-managed database (on-prem or EC2), DB security tools attach in one of four ways:
+
+| Attachment mode | How it works | Survives on RDS/Aurora? |
+|-----------------|--------------|-------------------------|
+| **Network sniffing** (TAP / SPAN / port-mirror) | A sensor passively mirrors DB traffic off a switch span port or hardware TAP | 🔴 **Breaks** — AWS gives you no port mirroring / SPAN on the managed network |
+| **Host agent** (OS daemon on the DB server) | A daemon on the DB host inspects local sessions, blocks bypass/console access, or hooks the engine | 🔴 **Breaks** — there is no OS access on managed RDS/Aurora |
+| **DB-engine plug-in** (library loaded into the engine) | A shared library / plugin installed into the DBMS performs encryption or control inside the engine | 🔴 **Breaks** — you cannot install arbitrary engine plugins on managed RDS |
+| **Inline gateway / proxy** ("") | Clients connect to the proxy; the proxy connects to the DB. All policy is enforced in the proxy | 🟢 **Survives** — deploy the proxy in the VPC in front of the RDS endpoint |
+| **API / app-side library** (for encryption) | An encryption library runs on the *application* server, encrypting before the query reaches the DB | 🟢 **Survives** — it never touches the DB host/engine |
+
+**The migration rule of thumb:**
+1. **Access control / audit** → must move to the vendor's **gateway/proxy mode** in the VPC, and/or be replaced by **RDS Database Activity Streams (DAS)** for the audit trail + **RDS Proxy/IAM auth/security groups** for access enforcement.
+2. **Encryption** → **plug-in mode breaks**; switch to the vendor's **API/app-side mode**, or replace with **RDS/Aurora KMS encryption-at-rest** (the TDE equivalent) plus **application-level column encryption** for field-level needs.
+3. **DAS is the integration point.** AWS explicitly designed Database Activity Streams to be consumed by third-party compliance tools (it documents IBM Guardium and Imperva integration). This is the pattern Korean vendors must adopt on RDS — **consume the DAS Kinesis stream instead of sniffing the wire.**
+
+> ⚠️ **Vendor naming — get this right with the customer.** **Chakra Max is a WareValley product.** **Petra and Petra Cipher are SINSIWAY products.** **DBSafer is PNPSECURE.** **D'Amo is Penta Security.** These are frequently conflated; getting the vendor wrong in a customer meeting costs credibility.
+
+---
+
+## 1. Access-Control & Audit Tools (network/gateway class)
+
+These sit between users/applications and the DB to enforce who-can-run-what and to record 100% of access for audit. On managed RDS, the sniffing and host-agent modes die; the **gateway mode is the survivor**, backed by DAS.
+
+### 1.1 Chakra Max — WareValley
+
+| Aspect | Detail |
+|--------|--------|
+| **Function** | DB access control + server/system access control + integrated account management + 100% audit logging, SQL-level control, data masking. Marketed as "Korea's first database access control." |
+| **On-prem architecture** | Supports **agent**, **agent-less TAP/sniffing**, and a **"Software TAP"** capture mode marketed for cloud/virtualized environments. Integrated management across on-prem + cloud + virtualized. |
+| **RDS/Aurora support** | **Claimed yes** — WareValley's supported-DBMS list explicitly includes **Aurora** (and Redshift), and lists AWS/Azure/GCP as supported clouds. The viable mechanism on managed RDS is the **Software TAP / proxy-style capture**, since hardware TAP/SPAN is impossible. |
+| **What breaks** | Hardware-mirroring/SPAN sniffing 🔴; host agent on the DB OS 🔴. |
+| **What survives** | Software TAP / inline gateway deployed in the VPC 🟢. |
+| **RDS pattern** | Run Chakra Max in **Software-TAP / proxy mode inside the VPC** in front of the RDS endpoint; pair with **RDS Database Activity Streams** for the tamper-resistant audit trail and **RDS Proxy + IAM auth** for connection control. |
+| **Confidence** | Aurora/cloud support: **verified** (vendor product page). Specific managed-RDS deployment mode: **inference** from how each mode works — request WareValley's "AWS RDS deployment guide" to confirm it is *certified*, not merely *possible*. |
+
+### 1.2 DBSafer — PNPSECURE
+
+| Aspect | Detail |
+|--------|--------|
+| **Function** | DB access control & audit (market-leading in Korea). Product family: DBSAFER DB / AM / OS / IM, plus INFOSAFER, DATACRYPTO, FaceLocker. |
+| **On-prem architecture** | **Primary mode is Gateway/Proxy** — " / Gateway(Proxy) ." A **Server Agent** additionally catches bypass/direct (console) connections that don't traverse the gateway. Client component "PC Assist." |
+| **RDS/Aurora support** | **Yes — architecturally the best fit of the access-control tools**, because its native mode is *already* gateway/proxy, not sniffing. "DBSAFER for Cloud" offers gateway-mode DB access control plus a server-agent variant; supports ~10 clouds. |
+| **What breaks** | Server-Agent OS-level bypass control 🔴 (works on EC2-hosted DBs, not managed RDS — no OS). |
+| **What survives** | Gateway/Proxy mode 🟢 — the recommended deployment. |
+| **RDS pattern** | Deploy the **DBSAFER Gateway in the VPC** in front of RDS. Replace the lost OS-level bypass agent with **network enforcement**: security groups + route design so *all* client traffic is forced through the gateway and there is no direct path to the RDS endpoint. Add DAS for tamper-resistant audit. |
+| **Confidence** | Gateway = native mode and RDS-viable: **high**. Specific managed-RDS certification: **medium** — confirm with vendor. |
+
+### 1.3 Petra — SINSIWAY
+
+| Aspect | Detail |
+|--------|--------|
+| **Function** | DB access control, detailed SQL analysis, REST API, centralized policy. (SINSIWAY's *encryption* product is **Petra Cipher** — see §2.1.) |
+| **On-prem architecture** | Supports **Gateway, Sniffing, Agent, and Hybrid** modes. |
+| **RDS/Aurora support** | **Yes via Gateway mode.** SINSIWAY's cloud page lists AWS, Azure, NCP, KT, gabia and integrates access control + encryption for cloud. |
+| **What breaks** | Sniffing 🔴, Agent 🔴, Hybrid (the sniffing/agent halves) 🔴. |
+| **What survives** | Gateway mode 🟢. |
+| **RDS pattern** | **Gateway mode in the VPC** + DAS for audit. |
+| **Confidence** | Cloud/AWS support: **verified**. Managed-RDS specifics: **medium**. |
+
+> **Why gateway mode is the universal survivor:** managed RDS exposes only a network endpoint. Anything that needs to see the wire passively (sniffing) or sit on the host (agent) loses its vantage point. A gateway *is* a network endpoint that clients dial instead of the DB — it relocates cleanly into the VPC. The migration cost is **forcing all traffic through it** (no direct route to RDS) and **sizing/HA-ing the proxy** as a new in-path component.
+
+---
+
+## 2. DB Encryption Tools (encryption class)
+
+These satisfy the PIPA/ISMS-P mandate to encrypt resident registration numbers, passwords (one-way), account/card numbers, and biometrics. On managed RDS the **plug-in/engine and OS-volume modes break**; the **API/app-side mode survives**, and **KMS at-rest encryption is the managed TDE equivalent**.
+
+### 2.1 Petra Cipher — SINSIWAY
+
+| Aspect | Detail |
+|--------|--------|
+| **Function** | DB/file encryption, standardized key management, triple-key, duplicate-encryption prevention. |
+| **On-prem architecture** | Two methods — **(1) Plug-in:** encryption/decryption **library installed on the DB server** (transparent to the app); **(2) API:** library installed on the **application server** (Java/C/PL-SQL), DBMS-independent. Explicitly *not* a gateway model. |
+| **What breaks** | **Plug-in mode** 🔴 — you cannot install a library into the managed RDS engine/OS. |
+| **What survives** | **API mode** 🟢 — runs on your app server, encrypts before sending to RDS. |
+| **RDS pattern** | Use **API mode** for column/field encryption on RDS, **or** replace with **app-side AWS Encryption SDK + KMS**. For at-rest/"TDE" needs use **RDS/Aurora KMS encryption-at-rest** (see §4). |
+
+### 2.2 D'Amo / D.AMO — Penta Security
+
+| Aspect | Detail |
+|--------|--------|
+| **Function** | DB/data encryption; the market-leading Korean DB encryption brand. Supports column-level encryption and **Format-Preserving Encryption (FPE)**. |
+| **On-prem architecture** | Multi-model: **API/app-side** (D.AMO BA-SCP — "API installed in the application server to encrypt data and then sends queries to the DBMS"); **DBMS-engine / column-level** (D.AMO DE); **OS/volume-level** (D.AMO KE). |
+| **What breaks** | KE (OS/volume) 🔴; DE (DB-engine plug-in) 🟠 questionable on managed RDS. |
+| **What survives** | **BA-SCP (API mode)** 🟢 — runs on the app server. |
+| **RDS pattern** | **D.AMO BA-SCP API mode** for column-level encryption, or **AWS Encryption SDK + KMS**; plus **RDS KMS at-rest** for the TDE-equivalent layer. Confirm BA-SCP/RDS support with Penta. |
+
+### 2.3 CUBE-One — Comtrue Technology
+
+| Aspect | Detail |
+|--------|--------|
+| **Function** | High-performance, non-stop DB encryption with **searchable encrypted indexes**, **column-level** PII encryption, FIPS-140 / Korean NIS-validated crypto module, separate access-log server. De-identification/PII tooling in the portfolio. Supports Oracle, MS-SQL, PostgreSQL. |
+| **On-prem architecture** | Column-level encryption; the **install mechanism (DB-server plug-in vs. app API) is not publicly confirmed** — this is the key question to ask the vendor. |
+| **What breaks / survives** | **Unverified.** By analogy to other Korean encryption tools, expect **API/app-side to survive** and **DB-server-plugin to break**. PostgreSQL support is a positive signal for Aurora PostgreSQL. |
+| **RDS pattern** | If an API/app-side mode exists, use it; otherwise app-side encryption + RDS KMS at-rest. **Flag as a gap — confirm install mode with Comtrue before committing the plan.** |
+
+### 2.4 Other tools you may encounter
+
+- **WareValley Log Catch** — personal-information access-record management (audit complement to Chakra Max).
+- **WareValley Orange / Orange Ade / Trusted Orange** — DBA/dev IDE tools, *not* security controls. They are **network SQL clients** and migrate **trivially** to RDS (no OS/host access needed). 🟢
+- **PNPSECURE DATACRYPTO** — encryption companion to DBSafer; treat like other encryption tools (API mode survives).
+- **Penta Security / generic** — D'Amo covered above.
+
+---
+
+## 3. Decision Matrix (use this in the migration plan)
+
+| Tool (vendor) | Function | On-prem mode | Survives on RDS/Aurora? | RDS approach |
+|---|---|---|---|---|
+| Chakra Max (WareValley) | Access ctrl + audit | TAP/sniffing, agent, Software-TAP | sniffing/agent 🔴; Software-TAP/proxy 🟢 (Aurora listed) | Proxy/Software-TAP in VPC + DAS |
+| DBSafer (PNPSECURE) | Access ctrl + audit | **Gateway/Proxy** + server agent | gateway 🟢 (best fit); agent 🔴 | Gateway in VPC + DAS |
+| Petra (SINSIWAY) | Access ctrl | Gateway/Sniffing/Agent/Hybrid | gateway 🟢; sniffing/agent 🔴 | Gateway mode + DAS |
+| Petra Cipher (SINSIWAY) | Encryption | Plug-in (DB server) / API (app) | plug-in 🔴; API 🟢 | API mode or KMS at-rest |
+| D'Amo (Penta) | Encryption | API / DB-engine / OS-volume | API (BA-SCP) 🟢; DE 🟠; KE 🔴 | BA-SCP API or KMS at-rest |
+| CUBE-One (Comtrue) | Encryption + de-id | Column encryption (mode unconfirmed) | **unverified** — confirm | API/app-side if available; KMS at-rest |
+| Orange family (WareValley) | DBA/dev tool | Network client | 🟢 (just a SQL client) | No change |
+
+---
+
+## Global Enterprise Tools
+
+Korean enterprises (and Korean subsidiaries of multinationals) frequently run a **global**
+DAM/audit platform — **IBM Guardium** or **Imperva** — alongside or instead of the domestic
+tools above, especially in finance and regulated industries. These follow the *same survival
+logic*: host agents and wire-sniffing die on managed RDS, while **inline proxy modes and
+Database Activity Streams (DAS) consumption survive**. AWS explicitly documents DAS integration
+for both, so they are the cleanest "consume DAS instead of sniffing" pattern.
+
+### IBM Guardium
+
+| Aspect | Detail |
+|--------|--------|
+| Modes | S-TAP (host agent) / External S-TAP (inline proxy) / Guardium Insights (SaaS+API) |
+| S-TAP on RDS | 🔴 Red — breaks — no OS to install the host agent on |
+| External S-TAP | 🟢 Green — survives — deploy as a proxy in the VPC in front of the RDS endpoint |
+| Guardium Insights + DAS | 🟢 Green — survives — consume Database Activity Streams via Kinesis |
+| RDS pattern | External S-TAP for inline blocking + Guardium Insights consuming DAS for the audit trail |
+
+### Imperva DAM
+
+> ⚠️ **Unverified vendor detail** — the mode/RDS-survival mapping below follows the same
+> structure as IBM Guardium and AWS's documented Imperva↔DAS integration (§4.1), but has
+> not been confirmed against Imperva's current AWS deployment guide.
+> **Verify with the vendor before using in a customer plan.**
+
+| Aspect | Detail |
+|--------|--------|
+| Modes | Agent (host-based gateway agent) / Network sniffing (SecureSphere gateway appliance) / Cloud — DAS consumption |
+| Agent on RDS | 🔴 Red — breaks — no OS to host the agent |
+| Network sniffing | 🔴 Red — breaks — no SPAN/port-mirror on the managed RDS network |
+| DAS consumption | 🟢 Green — survives — Imperva consumes Database Activity Streams via Kinesis (AWS-documented for Aurora PostgreSQL) |
+| RDS pattern | Imperva consuming DAS via Kinesis for monitoring/audit + network enforcement (security groups + RDS Proxy) for access control |
+
+### Thales CipherTrust / Vormetric
+| Aspect | Detail |
+|--------|--------|
+| **Modes** | CTE (Transparent Encryption — file/volume agent on host) / CADP (app-side encryption library) / CipherTrust Manager (central key management) |
+| **CTE on RDS** | 🔴 Breaks — encrypts at OS volume level, no OS access on managed RDS |
+| **CADP (app-side)** | 🟢 Survives — encryption happens in the application layer, not the DB host |
+| **CipherTrust Manager + AWS KMS XKS** | 🟢 Survives — CipherTrust Manager acts as external key authority for KMS via External Key Store; RDS uses KMS, KMS delegates to CipherTrust |
+| **RDS pattern** | CADP for column-level encryption + CipherTrust Manager via KMS External Key Store (XKS) for key authority. Maintains compliance requirement of external key custody. |
+
+### Bulk Decrypt → Re-Encrypt Migration Procedure
+
+When transitioning from plug-in/agent encryption to app-side or KMS:
+
+1. **Inventory**: Identify all encrypted columns/tablespaces on source
+2. **Decrypt in place**: On the source DB, bulk-decrypt data (requires the original encryption key)
+3. **Migrate**: Move decrypted data to Aurora/RDS via chosen method
+4. **Re-encrypt on target**: Enable KMS at-rest encryption (Aurora default) + implement app-side column encryption (CADP/pgcrypto/AES_ENCRYPT) for field-level needs
+5. **Verify**: Confirm encrypted columns are correctly readable through the application
+6. **Decommission old keys**: After rollback window expires, revoke old encryption keys
+
+> ⚠️ This is often the longest task in the migration — budget 2-4 weeks for large databases with many encrypted columns. The decrypt step may require a maintenance window if the source DB is under load.
+
+### Gateway/Proxy Deployment Checklist
+
+When deploying security tools in gateway/proxy mode in front of RDS:
+
+> ⚠️ **Baseline checklist** — derived from the gateway/proxy migration concerns in this
+> document (§1.2 DBSafer, §4.2 access control). Extend it with the specific vendor's
+> deployment guide before using in a customer plan.
+
+- [ ] **Latency impact measured** (target the added round-trip vs. direct RDS connection; benchmark p50/p99 before committing)
+- [ ] **High availability** — deploy the gateway across ≥2 AZs; a single proxy instance is now a single point of failure in front of the DB
+- [ ] **Capacity / sizing** — size the proxy for peak concurrent connections + throughput; it is a new in-path bottleneck
+- [ ] **No bypass path** — security groups + route tables force *all* client traffic through the gateway; RDS in private subnets only, `PubliclyAccessible = false`, no direct route to the RDS endpoint
+- [ ] **Connection pooling interaction** — confirm the gateway coexists with RDS Proxy / app-side pools without double-pooling or idle-timeout conflicts
+- [ ] **TLS termination** — decide where TLS terminates (client→gateway→RDS); enforce encryption in transit on both hops (`require_secure_transport` / `rds.force_ssl`)
+- [ ] **Audit integration** — gateway logs forwarded to the SIEM, and/or DAS enabled in parallel for the tamper-resistant trail
+- [ ] **Failover behavior** — define what happens if the gateway is unavailable (fail-closed for security vs. fail-open for availability — a compliance decision)
+- [ ] **Vendor RDS certification confirmed** — the vendor's gateway mode is *certified* on managed RDS, not merely possible (request the AWS deployment guide)
+
+---
+
+## 4. AWS-Native Replacements
+
+### 4.1 Audit — replace sniffing-based DB audit with Database Activity Streams (DAS)
+
+**Amazon RDS / Aurora Database Activity Streams** captures, near-real-time: SQL commands, connection info, DML row counts, accessed objects, bind variables, session/network info. Passwords are redacted. The stream is pushed to an **auto-managed Kinesis** data stream, consumable by Firehose/Lambda.
+
+- **Separation of duties is built in**: DBAs cannot access the stream collection/processing pipeline → tamper-resistant audit, which is exactly what the Korean audit appliances provide on-prem.
+- **Supports async and sync modes** (sync blocks the DB if the stream can't keep up — choose per compliance strictness).
+- **Third-party integration is a first-class design goal**: AWS documents DAS integration with IBM Security Guardium and Imperva for Aurora PostgreSQL. **Korean vendors plug into DAS/Kinesis the same way.**
+- **Complementary AWS services**: CloudWatch Logs (engine audit logs — MariaDB Audit Plugin for MySQL/MariaDB, `pgaudit` for PostgreSQL, SQL Server Audit), CloudTrail (control-plane API audit), EventBridge, GuardDuty RDS Protection.
+
+```bash
+# Enable Database Activity Streams on an Aurora cluster (sync mode)
+aws rds start-activity-stream \
+ --resource-arn arn:aws:rds:ap-northeast-2:ACCOUNT:cluster:my-aurora-cluster \
+ --mode sync \
+ --kms-key-id arn:aws:kms:ap-northeast-2:ACCOUNT:key/KEY-ID \
+ --apply-immediately
+```
+
+### 4.2 Access control — replace the inline DB-access appliance
+
+- **RDS Proxy** — managed proxy that can **enforce IAM authentication**, integrates **Secrets Manager**, and provides private VPC-only access. This is the native analog of the Korean "" mode. ⚠️ It does **not** give the fine-grained SQL-command-level policy/masking the Korean tools provide — for those, run the vendor's **gateway mode** in the VPC alongside it.
+- **Network enforcement** — security groups + route design so all traffic funnels through the proxy/gateway, replacing the lost OS-level bypass agent. RDS in **private subnets only**, `PubliclyAccessible = false`.
+- **IAM database authentication** + least-privilege DB roles for the authentication mandate.
+
+### 4.3 Encryption — replace TDE plug-in / OS-volume encryption
+
+- **RDS/Aurora encryption at rest = the managed TDE equivalent**: AES-256, KMS-managed keys, covers storage + backups + replicas + snapshots, no app changes. ⚠️ **Must be enabled at instance creation and cannot be disabled later**; KMS keys are Region-specific. (Note: newer Aurora clusters are auto-encrypted at rest by default.)
+- **Column/field-level encryption** (which at-rest encryption does *not* provide): app-side API encryption — vendor API mode (Petra Cipher API, D.AMO BA-SCP) or **AWS Encryption SDK + KMS**.
+- **In transit**: force TLS (`rds.force_ssl=1` for PostgreSQL, `require_secure_transport=ON` for MySQL/Aurora MySQL).
+- ⚠️ **Algorithm caveat for Korean auditors**: KMS uses AES-256. If a regulator insists on **SEED/ARIA** for specific fields, that must be done at the **application/column layer** with the vendor's API mode (which supports the Korean ciphers) — RDS at-rest cannot satisfy a SEED/ARIA mandate by itself. See [regulatory-compliance.md](regulatory-compliance.md).
+
+---
+
+## 5. Questions to Ask the Customer (assessment checklist)
+
+When the as-is database is wrapped in Korean security tooling, surface these **before** choosing a migration method — they frequently change the target architecture:
+
+- [ ] **Which access-control/audit product, and in which mode?** (sniffing / agent / gateway). If sniffing or agent only → gateway licensing/redesign is a prerequisite task.
+- [ ] **Which encryption product, and in which mode?** (plug-in / API / OS-volume). If plug-in or OS-volume → app-side re-architecture or KMS migration is a prerequisite task.
+- [ ] **Does the vendor have a *certified* AWS RDS/Aurora deployment guide?** Request it. "Possible" ≠ "supported."
+- [ ] **What is encrypted today, with which algorithm?** (RRN, passwords, account numbers, biometrics; SEED/ARIA/AES). Maps to the field-level encryption plan.
+- [ ] **What is the audit-log retention requirement?** (1 yr / 2 yr — see [regulatory-compliance.md](regulatory-compliance.md)). Drives Kinesis→S3/CloudWatch retention + S3 Object Lock immutability.
+- [ ] **Is this a financial workload subject to network separation (mangbunri)?** If it touches unique-ID / personal-credit info, plan the stricter separated regime (private subnets, no IGW, PrivateLink, Direct Connect).
+- [ ] **Will the existing audit/SIEM consume DAS?** Confirm the vendor or in-house SIEM can read the Kinesis stream, or plan a Firehose→S3/OpenSearch bridge.
+
+---
+
+## 6. Honesty / Confidence Notes
+
+- Vendor product **existence and function** are verified from vendor pages. **Granular "does mode X work on *managed* RDS"** is rarely stated by vendors verbatim — those cells are **architecture-grounded inference** (how each mode interacts with the loss of OS + network visibility), not vendor warranties.
+- For a customer-facing plan, **request each vendor's AWS RDS deployment guide** and verify whether their gateway/API mode is *certified* on managed RDS, not merely possible.
+- CUBE-One's install mechanism and Comtrue's de-identification product specifics are **unconfirmed gaps** — flag and confirm with the vendor.
+- This document reflects research as of **2026-06**. Vendor cloud support evolves quickly; re-verify before publishing a customer plan.

--- a/db-migration-agent-skill/shared/reference/troubleshooting.md
+++ b/db-migration-agent-skill/shared/reference/troubleshooting.md
@@ -1,0 +1,30 @@
+# Troubleshooting Quick Reference
+
+> Symptom → likely cause → fix, across all phases and engines. Scan this FIRST when
+> anything fails; each fix links back to the phase that prevents it.
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| DMS: `binlog truncated` | Binlogs expired before CDC read them | Increase `expire_logs_days`, restart full load |
+| DMS: Out of memory | Instance undersized or LOBs too large | Scale up instance, use Limited LOB Mode |
+| DMS: Increasing CDC latency | Target can't keep up | Enable `BatchApplyEnabled`, scale target |
+| Aurora: `Access denied for user` | DEFINER clause references non-existent user | Strip DEFINERs from schema objects |
+| Aurora: Stored proc fails | Uses SUPER privilege or unsupported syntax | Rewrite proc without SUPER, fix syntax |
+| Slow queries after migration | Missing optimizer statistics | `ANALYZE TABLE` on all tables |
+| Connection failures | Security group misconfiguration | Verify SG rules between app → Aurora |
+| `ERROR 1227` on `SET GLOBAL read_only` | Account lacks SUPER / READ_ONLY ADMIN | Use the freeze fallback: stop all write clients, verify writers=0 via processlist (cutover-procedures.md §freeze fallback) |
+| App can't reach new DB after secret rotation | DB host hardcoded in systemd/config, not in the secret | Change the systemd `ExecStart`/config (highest-priority source wins); backfill host into the secret (cutover-procedures.md §client discovery) |
+| Migration load or app fails with TLS/SSL error | `require_secure_transport=ON` on target | Add TLS params to load tool + connector (target-provisioning.md §TLS-Enforcement Gate) |
+| Schema drift on first app connection to new DB | ORM `ddl-auto=update`/auto-migrate | Set `validate`/`none` before cutover (cutover-procedures.md §client discovery) |
+| MyISAM error on Aurora | MyISAM not supported | Convert to InnoDB before migration |
+| TDE error | Encrypted tablespaces | Decrypt before migration |
+| Oracle: `ORA-39083` on import | Missing privilege or target tablespace | Grant on target user; `METADATA_REMAP` tablespace |
+| Oracle: `ORA-31693` table load failed | Tablespace quota / space | `ALTER USER ... QUOTA UNLIMITED`; grow storage |
+| Oracle: invalid objects after import | Dependencies / compile order | `UTL_RECOMP.RECOMP_PARALLEL` (no `utlrp.sql` — no shell) |
+| Oracle: can't import (FULL mode) | RDS blocks FULL mode | Use schema/table mode; exclude SYS-owned Scheduler objects |
+| Oracle: TDE dump won't import | `ENCRYPTION_MODE=TRANSPARENT` | Re-export with `ENCRYPTION_MODE=PASSWORD` |
+| SQL Server: restore fails, higher version | `.bak` from newer engine | Target RDS engine version must be ≥ source |
+| SQL Server: orphaned users post-restore | Login SID mismatch | Recreate login w/ same SID, or `ALTER USER ... WITH LOGIN` |
+| SQL Server: FILESTREAM restore rejected | FILESTREAM filegroup in `.bak` | Remove FILESTREAM; redesign as BLOB/S3 |
+| SQL Server: missing Agent jobs/logins | Server-level objects not in user `.bak` | Script + recreate separately (execution-runbooks.md §schema objects) |
+

--- a/db-migration-agent-skill/shared/reference/validation-patterns.md
+++ b/db-migration-agent-skill/shared/reference/validation-patterns.md
@@ -1,0 +1,534 @@
+# Data Validation Patterns
+
+## Validation Strategy
+
+Validation happens at three points:
+1. **During migration** — DMS built-in validation (continuous)
+2. **Pre-cutover** — Manual validation before switching traffic
+3. **Post-cutover** — Application-level verification after go-live
+
+---
+
+## 1. DMS Built-in Validation
+
+### Enable Validation in Task Settings
+
+```json
+{
+  "ValidationSettings": {
+    "EnableValidation": true,
+    "ThreadCount": 5,
+    "ValidationMode": "ROW_LEVEL",
+    "FailureMaxCount": 10000,
+    "HandleCollationDiff": "true",
+    "RecordSuspendedState": "RECORD_ONLY",
+    "SkipLobColumns": false,
+    "TableFailureMaxCount": 1000,
+    "ValidationOnly": false,
+    "ValidationPartialLobSize": 0
+  }
+}
+```
+
+### Monitor Validation Status
+
+```bash
+# Check table-level validation status
+aws dms describe-table-statistics \
+  --replication-task-arn $TASK_ARN \
+  --query 'TableStatistics[].{
+    Table: TableName,
+    State: ValidationState,
+    Pending: ValidationPendingRecords,
+    Failed: ValidationFailedRecords,
+    Suspended: ValidationSuspendedRecords
+  }' --output table
+```
+
+### Validation States
+
+| State | Meaning | Action |
+|-------|---------|--------|
+| `Not enabled` | Validation not configured | Enable in task settings |
+| `Pending records` | Records queued for validation | Wait — normal during active CDC |
+| `Mismatched records` | Rows differ between source/target | Investigate — check LOB handling |
+| `Suspended records` | Validation couldn't compare (e.g., no PK) | Add PK or accept limitation |
+| `No primary key` | Table has no PK for row-level comparison | Add PK or use manual validation |
+| `Table error` | Validation encountered an error | Check DMS logs |
+| `Validated` | All rows match ✅ | Good to proceed |
+
+### Common Validation Failures
+
+| Failure Type | Cause | Resolution |
+|-------------|-------|------------|
+| Mismatched records (small count) | CDC latency — records changed after validation | Re-validate after CDC catches up |
+| Mismatched records (LOB tables) | LOB mode truncation | Use Full LOB Mode or increase `LobMaxSize` |
+| Suspended records | Table lacks primary key | Add PK, or accept and do manual validation |
+| All records suspended | Permissions issue on source/target | Check DMS user grants |
+
+---
+
+## 2. Pre-Cutover Manual Validation
+
+### 2.1 Row Count Comparison
+
+**MySQL:**
+```sql
+-- Generate comparison queries dynamically
+SELECT CONCAT(
+  'SELECT ''', table_name, ''' AS tbl, COUNT(*) AS cnt FROM `', table_name, '` UNION ALL'
+) FROM information_schema.tables
+WHERE table_schema = 'your_db' AND table_type = 'BASE TABLE'
+ORDER BY table_name;
+
+-- Run the generated query on both source and target, compare results
+```
+
+**PostgreSQL:**
+```sql
+-- Generate comparison queries
+SELECT format('SELECT %L AS tbl, COUNT(*) AS cnt FROM %I.%I UNION ALL',
+  tablename, schemaname, tablename)
+FROM pg_tables WHERE schemaname = 'public'
+ORDER BY tablename;
+```
+
+**Automation script:**
+```bash
+#!/bin/bash
+# Compare row counts between source and target
+# Credentials via MYSQL_PWD env or --defaults-extra-file — never in argv (see source-assessment.md)
+export MYSQL_PWD=${MYSQL_PWD:?set via Secrets Manager fetch}
+TABLES=$(mysql -h $SOURCE -u $USER -N -e \
+  "SELECT table_name FROM information_schema.tables WHERE table_schema='$DB'")
+
+echo "TABLE | SOURCE | TARGET | MATCH"
+echo "------|--------|--------|------"
+for TABLE in $TABLES; do
+  SRC=$(mysql -h $SOURCE -u $USER -N -e "SELECT COUNT(*) FROM $DB.$TABLE")
+  TGT=$(mysql -h $TARGET -u $USER -N -e "SELECT COUNT(*) FROM $DB.$TABLE")
+  if [ "$SRC" = "$TGT" ]; then
+    MATCH="✅"
+  else
+    MATCH="❌ (diff: $((TGT - SRC)))"
+  fi
+  echo "$TABLE | $SRC | $TGT | $MATCH"
+done
+```
+
+### 2.2 Checksum Verification
+
+**MySQL — pt-table-checksum (Percona Toolkit):**
+```bash
+# Install Percona Toolkit
+apt-get install percona-toolkit
+
+# Run checksum comparison
+pt-table-checksum \
+  --host=$SOURCE \
+  --user=$USER \
+  \
+  --databases=$DB \
+  --replicate=percona.checksums \
+  --no-check-binlog-format \
+  --chunk-size=5000
+
+# Check results
+pt-table-sync --print --replicate percona.checksums \
+  --host=$SOURCE --user=$USER   # password via MYSQL_PWD
+```
+
+**MySQL — Native CHECKSUM TABLE (simpler but locks tables):**
+```sql
+-- Quick checksums (READ lock during execution)
+CHECKSUM TABLE orders, products, users, cart_items;
+-- Compare output between source and target
+```
+
+**PostgreSQL — Hash-based verification:**
+```sql
+-- MD5 hash of critical columns for a table
+SELECT md5(string_agg(
+  md5(CAST(id AS text) || CAST(amount AS text) || CAST(status AS text) || CAST(created_at AS text)),
+  '' ORDER BY id
+)) AS table_hash
+FROM orders;
+-- Run on both source and target, compare hashes
+```
+
+### 2.3 Sample Record Deep Comparison
+
+```sql
+-- Compare the last N records (catching recent CDC-applied changes)
+-- Source:
+SELECT * FROM orders WHERE id IN (
+  SELECT id FROM orders ORDER BY id DESC LIMIT 100
+) ORDER BY id;
+
+-- Target:
+SELECT * FROM orders WHERE id IN (
+  SELECT id FROM orders ORDER BY id DESC LIMIT 100
+) ORDER BY id;
+
+-- Export to CSV and diff:
+-- mysql -h $SOURCE ... --batch --raw > /tmp/source_sample.csv
+-- mysql -h $TARGET ... --batch --raw > /tmp/target_sample.csv
+-- diff /tmp/source_sample.csv /tmp/target_sample.csv
+```
+
+### 2.4 Referential Integrity Check
+
+Run on the TARGET to ensure FK relationships are intact:
+
+```sql
+-- MySQL: Find orphaned references
+-- Orders referencing non-existent users
+SELECT o.id, o.user_id FROM orders o
+LEFT JOIN users u ON o.user_id = u.id
+WHERE u.id IS NULL;
+
+-- Order items referencing non-existent orders
+SELECT oi.id, oi.order_id FROM order_items oi
+LEFT JOIN orders o ON oi.order_id = o.id
+WHERE o.id IS NULL;
+
+-- Order items referencing non-existent products
+SELECT oi.id, oi.product_id FROM order_items oi
+LEFT JOIN products p ON oi.product_id = p.id
+WHERE p.id IS NULL;
+```
+
+```sql
+-- PostgreSQL: Check all FK constraints
+SELECT conname AS constraint_name,
+  conrelid::regclass AS table_name,
+  confrelid::regclass AS referenced_table
+FROM pg_constraint
+WHERE contype = 'f'
+  AND NOT convalidated;  -- Shows invalid (violated) constraints
+
+-- Validate all constraints (will error if violations exist)
+-- ALTER TABLE orders VALIDATE CONSTRAINT fk_user_id;
+```
+
+### 2.5 Schema Object Verification
+
+```sql
+-- MySQL: Compare stored procedure counts
+SELECT ROUTINE_TYPE, COUNT(*) FROM information_schema.routines
+WHERE ROUTINE_SCHEMA = 'your_db' GROUP BY ROUTINE_TYPE;
+
+-- Compare trigger counts
+SELECT COUNT(*) FROM information_schema.triggers WHERE TRIGGER_SCHEMA = 'your_db';
+
+-- Compare view counts
+SELECT COUNT(*) FROM information_schema.views WHERE TABLE_SCHEMA = 'your_db';
+
+-- Compare index counts
+SELECT TABLE_NAME, COUNT(*) AS index_count FROM information_schema.statistics
+WHERE TABLE_SCHEMA = 'your_db' GROUP BY TABLE_NAME ORDER BY TABLE_NAME;
+```
+
+---
+
+## 3. Post-Cutover Validation
+
+### Application Smoke Tests
+
+Run immediately after cutover:
+
+```bash
+# Health check
+curl -sf https://your-app.example.com/health | jq '.database'
+
+# API functional tests (read)
+curl -sf https://your-app.example.com/api/products | jq '.[] | .id' | head -5
+
+# API functional tests (write)
+curl -sf -X POST https://your-app.example.com/api/orders \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": 1, "items": [{"product_id": 1, "quantity": 1}]}'
+
+# Verify the write persisted
+curl -sf https://your-app.example.com/api/orders?latest=1
+```
+
+### Performance Baseline Comparison
+
+```sql
+-- Run on Aurora after cutover — compare against source baseline
+-- Query 1: Complex join (typical read pattern)
+EXPLAIN ANALYZE SELECT o.id, o.total_amount, u.username
+FROM orders o JOIN users u ON o.user_id = u.id
+WHERE o.created_at > NOW() - INTERVAL 7 DAY
+ORDER BY o.created_at DESC LIMIT 100;
+
+-- Query 2: Aggregation (reporting pattern)
+EXPLAIN ANALYZE SELECT DATE(created_at) AS dt, COUNT(*) AS orders, SUM(total_amount) AS revenue
+FROM orders WHERE created_at > NOW() - INTERVAL 30 DAY
+GROUP BY DATE(created_at);
+```
+
+### Monitoring Checklist (First 24 Hours)
+
+- [ ] Application error rate < 0.1%
+- [ ] P99 query latency within 2x of baseline
+- [ ] No connection pool exhaustion
+- [ ] No deadlocks or lock waits > 10s
+- [ ] Aurora CPU < 70%
+- [ ] Aurora FreeableMemory > 2 GB
+- [ ] No replication lag on read replicas
+- [ ] Scheduled jobs (cron, events) executing successfully
+- [ ] Backup completed successfully (first automated backup)
+
+---
+
+## Validation Decision Matrix
+
+| Validation Type | When | Criticality | Automated? |
+|----------------|------|-------------|-----------|
+| DMS built-in | During migration | High | ✅ Yes |
+| Row count comparison | Pre-cutover, post-cutover | High | ✅ Scriptable |
+| Checksum verification | Pre-cutover (final) | Medium | ✅ pt-table-checksum |
+| Sample record comparison | Pre-cutover | Medium | Semi-auto |
+| Referential integrity | Post-full-load, pre-cutover | High | ✅ Scriptable |
+| Schema object count | After schema migration | Medium | ✅ Scriptable |
+| Application smoke tests | Post-cutover | Critical | ✅ CI/CD |
+| Performance comparison | Post-cutover (24h) | Medium | ✅ CloudWatch |
+
+---
+
+## 4. Application-Level & Engine-Specific Validation
+
+### Application-Level Validation
+
+Row counts and checksums prove the *bytes* moved; these checks prove the *application* still
+behaves identically against the target. Run them pre-cutover, on BOTH source and target, and diff.
+
+1. **Dual-read / shadow-traffic.** Configure the app to read from **both** source and target and
+   compare results before trusting the target. Spring Boot: route via `AbstractRoutingDataSource`.
+   Node.js: a read-through proxy that fans the read to both and diffs. Discrepancies surface
+   collation, timezone, or replication-lag issues no row-count check would catch.
+
+2. **Collation / sort-order check.** A different default collation silently reorders results and
+   breaks `ORDER BY`-dependent pagination and `=`/`LIKE` matching:
+   ```sql
+   SELECT id, name FROM products ORDER BY name LIMIT 100;
+   SHOW VARIABLES LIKE 'collation%';
+   ```
+   Run on BOTH, diff the results.
+
+3. **AUTO_INCREMENT / sequence high-water-mark.** Confirm the target's next-value counter sits
+   above the current max — otherwise the first inserts collide with existing PKs (see cutover-procedures.md §reset high-water marks):
+   ```sql
+   -- MySQL
+   SELECT TABLE_NAME, AUTO_INCREMENT FROM information_schema.tables WHERE TABLE_SCHEMA = 'your_db';
+   SELECT MAX(id) FROM orders;  -- Must be < AUTO_INCREMENT
+
+   -- PostgreSQL
+   SELECT schemaname, sequencename, last_value FROM pg_sequences;
+   ```
+
+4. **Aggregate fidelity.** Cheaper than a full checksum, catches truncated/duplicated rows and
+   numeric-type drift:
+   ```sql
+   SELECT COUNT(*) AS cnt, SUM(total_amount) AS total, MIN(created_at) AS earliest, MAX(id) AS max_id FROM orders;
+   ```
+   Run on BOTH, compare.
+
+5. **Timezone-shift detection.** A target with a different `time_zone` parameter shifts every
+   TIMESTAMP — easy to miss until reports are off by hours:
+   ```sql
+   SELECT id, created_at FROM orders ORDER BY id DESC LIMIT 10;
+   ```
+   Any shift between source and target = timezone parameter mismatch (see the Adjustments table in source-assessment.md).
+
+6. **Regression test suite.** Run your application's full test suite against the target database.
+   If no test suite exists: for each major table, create 1 record, read it back, update it, and
+   delete it — the minimum CRUD round-trip that proves the app's data layer works end-to-end.
+
+### Post-Version-Upgrade Validation
+
+> **Trigger — run this whole subsection ONLY when the source and target are different MAJOR
+> versions** (e.g. MySQL 5.7 → 8.0, MySQL 8.0 → 8.4, MariaDB 10.x → 11.x, PostgreSQL 13 → 15). A
+> logical dump can cross majors (execution-runbooks.md logical-dump note), but a version gap is a **behavioral-change surface**:
+> the bytes can match (row counts + `CHECKSUM TABLE` pass) while the *engine behaves differently*. The
+> checks above prove source↔target equivalence; these prove the workload survives the **version gap**
+> itself. Read [version-upgrades.md](version-upgrades.md) for the exact
+> per-version changes, then run the relevant checks below. Confirm the gap first — `SELECT VERSION();`
+> on both — and record findings in `migration-plan.md`.
+
+**1. Collation / sort-order ALGORITHM change (beyond the param check above).** The general collation
+check compares the *variable*; a major upgrade can change the default collation *algorithm* itself —
+MySQL 5.7 `utf8mb4_general_ci` vs 8.0 `utf8mb4_0900_ai_ci` sort and *compare* differently (accent/case
+weighting) even for identical charset and data. Two risks: silent re-ordering, and **new
+unique-key/PK collisions** (values that were distinct under the old collation become "equal").
+```sql
+-- run on BOTH; the new default collation may reorder rows even with the same charset
+SELECT id, name FROM products ORDER BY name, id LIMIT 200;        -- diff the two outputs
+-- what did each table/column actually resolve to after import?
+SELECT TABLE_NAME, TABLE_COLLATION FROM information_schema.TABLES WHERE TABLE_SCHEMA='your_db';
+SELECT TABLE_NAME, COLUMN_NAME, COLLATION_NAME FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA='your_db' AND COLLATION_NAME IS NOT NULL;
+-- prove comparison semantics changed:
+SELECT 'a' = 'A' COLLATE utf8mb4_0900_ai_ci AS ai_match;          -- 1 under the 8.0 default
+-- new collision risk on a string unique key / PK — must return ZERO rows:
+SELECT name, COUNT(*) c FROM products GROUP BY name HAVING c > 1;
+```
+
+**2. Auth-plugin compatibility (the app's real connector, not the `mysql` CLI).** 8.0 default became
+`caching_sha2_password`; **8.4 ships `mysql_native_password` OFF at startup.** Old connectors
+(Connector/J 5.1, libmysqlclient < 8.0, legacy PHP/Node drivers) then **fail to authenticate** even
+though the import succeeded.
+```sql
+-- TARGET: which plugin did each account land on after import?
+SELECT user, host, plugin FROM mysql.user;
+```
+```bash
+# Authenticate from a host running the APP's actual connector version (the newer mysql CLI hides this)
+mysql -h "$TARGET" -u appuser -p -e "SELECT CURRENT_USER(), CONNECTION_ID();"
+```
+Fix: upgrade the connector, **or** recreate the user on the legacy plugin
+(`ALTER USER 'appuser'@'%' IDENTIFIED WITH mysql_native_password BY '…'`; on 8.4 first set
+`mysql_native_password=ON` in the target parameter group — see version-upgrades.md MySQL 8.0→8.4).
+
+**3. `sql_mode` strictness — catch queries that worked before but fail now.** A newer major defaults
+to a stricter `sql_mode` (8.0 enables `ONLY_FULL_GROUP_BY`, `STRICT_TRANS_TABLES`, `NO_ZERO_DATE`,
+`NO_ZERO_IN_DATE`). `SELECT`s and writes that the source tolerated now **error**.
+```sql
+SELECT @@GLOBAL.sql_mode;   -- run on SOURCE and TARGET, diff the flag set
+```
+Drive the app's real workload (the regression suite, item 6) under the target `sql_mode`, and probe
+the known-risky shapes directly:
+```sql
+-- ONLY_FULL_GROUP_BY: a non-aggregated, non-grouped column now errors (1055) instead of returning arbitrary rows
+SELECT customer_id, order_date, SUM(total) FROM orders GROUP BY customer_id;
+-- NO_ZERO_DATE + STRICT: a zero/invalid date now errors instead of warning
+INSERT INTO events (created_at) VALUES ('0000-00-00');
+```
+Also scan existing data that strict mode will reject on the *next* UPDATE:
+```sql
+SELECT COUNT(*) FROM events WHERE created_at = '0000-00-00' OR created_at IS NULL;
+```
+Goal is to fix the queries/data; only as a temporary bridge, drop the offending flag from the target
+`sql_mode` parameter.
+
+**4. Reserved-word collisions in the existing schema.** A new major reserves identifiers your schema
+may already use (8.0: `RANK`, `ROW`, `ROWS`, `GROUPS`, `LEAD`, `LAG`, `OVER`, `CUME_DIST`,
+`DENSE_RANK`, `FIRST_VALUE`, `NTILE`, `PERCENT_RANK`, `RECURSIVE`, `SYSTEM`; 8.4: `PARALLEL`,
+`QUALIFY`, `TABLESAMPLE`, `MANUAL`; MariaDB 10.7: `ROW_NUMBER`, 11.6: `VECTOR`). The dump imports fine
+(mysqldump back-quotes identifiers) — but **unquoted application SQL referencing those names breaks at
+runtime.** Scan the migrated schema for collisions:
+```sql
+SELECT TABLE_NAME, COLUMN_NAME FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA='your_db'
+  AND UPPER(COLUMN_NAME) IN ('RANK','ROW','ROWS','GROUPS','LEAD','LAG','OVER','CUME_DIST',
+      'DENSE_RANK','FIRST_VALUE','LAST_VALUE','NTILE','PERCENT_RANK','RECURSIVE','SYSTEM',
+      'PARALLEL','QUALIFY','TABLESAMPLE','MANUAL','VECTOR','ROW_NUMBER');
+SELECT TABLE_NAME FROM information_schema.TABLES
+WHERE TABLE_SCHEMA='your_db'
+  AND UPPER(TABLE_NAME) IN ('RANK','ROW','ROWS','GROUPS','LEAD','LAG','OVER','CUME_DIST',
+      'DENSE_RANK','FIRST_VALUE','LAST_VALUE','NTILE','PERCENT_RANK','RECURSIVE','SYSTEM',
+      'PARALLEL','QUALIFY','TABLESAMPLE','MANUAL','VECTOR','ROW_NUMBER');
+```
+Any hit → `grep` the application for unquoted use of that identifier and add back-quotes, or rename
+the column. (PostgreSQL: query `information_schema.columns` the same way against the new major's
+reserved list; `SELECT quote_ident('row');` shows whether a name now needs quoting.)
+
+**5. Deprecated/removed functions & syntax in stored routines, triggers, views.** A logical dump
+*creates* routines, but a function or syntax **removed** in the new major fails at **call time, not
+import time** — so a green import hides it. Pull every body, scan for removed constructs, then
+actually execute each one:
+```sql
+SELECT ROUTINE_NAME, ROUTINE_TYPE, ROUTINE_DEFINITION FROM information_schema.ROUTINES
+WHERE ROUTINE_SCHEMA='your_db';
+SELECT TRIGGER_NAME, ACTION_STATEMENT FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA='your_db';
+SELECT TABLE_NAME, VIEW_DEFINITION FROM information_schema.VIEWS WHERE TABLE_SCHEMA='your_db';
+```
+Grep those bodies for things removed across the gap — e.g. 5.7→8.0: `PASSWORD()` (removed),
+`GROUP BY … ASC/DESC` (removed), `ENCODE`/`DECODE`/`DES_ENCRYPT`/`DES_DECRYPT` (removed),
+`SQL_CALC_FOUND_ROWS`/`FOUND_ROWS()` (deprecated). Then **exercise each routine** (the regression
+suite, item 6, must drive every routine/trigger/view path — MySQL has no bulk recompile):
+```sql
+CALL your_proc(/* representative args */);
+SELECT * FROM your_view LIMIT 1;
+```
+(Oracle's invalid-object scan + `UTL_RECOMP` is in the Oracle Validation block below; SQL Server: see
+`sys.dm_os_performance_counters … 'Deprecated Features'` in version-upgrades.md, then re-run modules.)
+
+**6. Default character-set change — verify data RENDERS, not just that counts match.** 5.7→8.0 default
+charset went `latin1`→`utf8mb4`. Row counts and even `CHECKSUM TABLE` can pass while text is
+**mojibake** if a `latin1` column's bytes were re-interpreted (double-encoded) during dump/reload.
+Verify actual rendering of multibyte / Korean / emoji data:
+```sql
+-- run on BOTH with a utf8mb4 client connection so the CLI itself doesn't mangle the comparison:
+--   mysql --default-character-set=utf8mb4 …
+SELECT id, name, HEX(name) AS name_hex, LENGTH(name) AS bytes, CHAR_LENGTH(name) AS chars
+FROM products WHERE name REGEXP '[^ -~]' LIMIT 50;     -- rows containing non-ASCII
+SELECT T.TABLE_NAME, CCSA.CHARACTER_SET_NAME
+FROM information_schema.TABLES T
+JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY CCSA
+  ON CCSA.COLLATION_NAME = T.TABLE_COLLATION
+WHERE T.TABLE_SCHEMA='your_db';
+```
+`CHAR_LENGTH` (characters) **must match on both**; `bytes` differing is expected if encoding differs,
+but the rendered glyphs must be identical. Garbled Korean/emoji = a charset bug in the dump step —
+re-dump with `--default-character-set` matching the source's *true* storage charset and reload.
+
+**7. Optimizer / query-plan regression.** A new major changes the cost model (MariaDB 11.0 time-based
+optimizer; MySQL 8.0 histograms + new CTE/derived-table handling) and plans can **regress**. Baseline
+`EXPLAIN` on the **source before cutover** and diff against the target.
+```sql
+-- SOURCE, pre-cutover: pull the hottest queries to baseline
+SELECT DIGEST_TEXT, COUNT_STAR, SUM_TIMER_WAIT
+FROM performance_schema.events_statements_summary_by_digest
+ORDER BY SUM_TIMER_WAIT DESC LIMIT 20;
+EXPLAIN FORMAT=JSON SELECT /* each top query */ … ;     -- capture access type, key, rows, cost
+-- TARGET (after ANALYZE TABLE so stats are fresh — Phase 9): same queries, compare
+EXPLAIN ANALYZE SELECT … ;                              -- MySQL 8.0.18+ / MariaDB 10.1+: real timing
+```
+A plan that drops an index, changes join order, or balloons `rows`/cost vs the baseline = regression
+→ pin with an index/optimizer hint, or (MariaDB 11.x) tune the new cost variables
+(`optimizer_disk_read_cost`, …). **PostgreSQL:** baseline with `EXPLAIN (ANALYZE, BUFFERS)` on both
+sides and pull the hot list from `pg_stat_statements`. See
+[version-upgrades.md](version-upgrades.md) "After the upgrade" item 4.
+
+### Oracle Validation (Oracle → RDS Oracle)
+
+```sql
+-- Monitor the running Data Pump job
+SELECT job_name, operation, job_mode, state FROM dba_datapump_jobs WHERE owner_name = USER;
+-- Read the import log (no OS access — use the rdsadmin helper)
+SELECT * FROM TABLE(rdsadmin.rds_file_util.read_text_file('DATA_PUMP_DIR','sample_imp.log'));
+-- Object counts by type (compare source vs target)
+SELECT object_type, COUNT(*) FROM dba_objects WHERE owner='SCHEMA_1' GROUP BY object_type ORDER BY 1;
+-- Invalid objects — then recompile (utlrp.sql can't run; no shell)
+SELECT object_name, object_type FROM dba_objects WHERE status='INVALID' AND owner='SCHEMA_1';
+EXEC UTL_RECOMP.RECOMP_PARALLEL(4,'SCHEMA_1');   -- or DBMS_UTILITY.COMPILE_SCHEMA('SCHEMA_1')
+-- Row counts (gather stats first, or COUNT(*) for exactness)
+EXEC DBMS_STATS.GATHER_SCHEMA_STATS('SCHEMA_1');
+SELECT table_name, num_rows FROM dba_tables WHERE owner='SCHEMA_1' ORDER BY table_name;
+```
+Common import errors: `ORA-39083` (object create failed — grant/tablespace; fix grants or `METADATA_REMAP`), `ORA-31693` (table data load failed — quota/space), `ORA-39166` (object not in dump / wrong schema).
+
+### SQL Server Validation (SQL Server → RDS SQL Server)
+
+```sql
+-- Integrity (you have db_owner on RDS); or use the AWSSQLServer-DBCC SSM automation document
+DBCC CHECKDB ('mydatabase') WITH NO_INFOMSGS, ALL_ERRORMSGS;
+-- Object counts (compare source vs target)
+SELECT type_desc, COUNT(*) FROM sys.objects GROUP BY type_desc ORDER BY type_desc;
+-- Row counts per table
+SELECT s.name, t.name, SUM(p.rows) AS row_count
+FROM sys.tables t JOIN sys.schemas s ON t.schema_id=s.schema_id
+JOIN sys.partitions p ON t.object_id=p.object_id AND p.index_id IN (0,1)
+GROUP BY s.name, t.name ORDER BY 1,2;
+-- Orphaned users (fix with ALTER USER ... WITH LOGIN — see execution-runbooks.md §schema objects)
+USE [mydatabase]; EXEC sp_change_users_login 'Report';
+-- Compare logins source vs target
+SELECT name, type_desc, sid FROM sys.server_principals
+WHERE type IN ('S','U','G') AND name NOT LIKE '##%##' ORDER BY name;
+-- TDE state (3 = encrypted)
+SELECT DB_NAME(database_id) db, encryption_state FROM sys.dm_database_encryption_keys;
+```
+

--- a/db-migration-agent-skill/shared/reference/version-upgrades.md
+++ b/db-migration-agent-skill/shared/reference/version-upgrades.md
@@ -1,0 +1,570 @@
+# Major Version Upgrades During Migration
+
+## Why this lives here
+
+A **logical-dump migration** (`mysqldump` / `pg_dump` / Data Pump → import) re-imports the data from
+scratch, so the target can run a **newer major version** than the source *in the same migration* — no
+separate upgrade project. This was used in the reference migration: **MariaDB 10.5.29 → 10.11.18**,
+verified byte-for-byte with `CHECKSUM TABLE` (e.g. `products` checksum `3581083405` identical across
+the version gap).
+
+This is an **opportunity** worth taking — you land on a supported, longer-life version and avoid a
+future in-place upgrade. But a version gap is also a **behavioral-change surface**. Review the items
+below for the source→target gap before choosing the target version, and add anything relevant to
+`migration-plan.md`.
+
+> **Physical methods cannot do this.** XtraBackup, RDS snapshot copy, and Read Replica promotion
+> preserve the on-disk format and **cannot skip a major version** — they require same-major (or a
+> subsequent in-place upgrade). Only logical dump (and, for the commercial engines, DMS / native
+> backup-restore / Data Pump) re-imports cleanly across majors.
+
+> **Scope.** Covers all RDS-supported engines **except Db2**: MySQL, MariaDB, PostgreSQL, Oracle,
+> SQL Server. Facts verified against vendor docs + AWS RDS docs current as of **2026-06**. Version
+> availability and exact minor thresholds drift — confirm with `aws rds describe-db-engine-versions`
+> before committing a target.
+
+---
+
+## General checklist (any engine)
+
+- [ ] **Reserved words** — a new major may reserve identifiers your schema/queries use as
+      column/table names. Quote them or rename. (See engine sections.)
+- [ ] **Deprecated / removed functions & syntax** — features deprecated in the old version may be
+      *removed* in the new one.
+- [ ] **Default value changes** — character set, collation, `sql_mode`, auth plugin, optimizer
+      defaults, compatibility level can differ between majors and silently change behavior.
+- [ ] **Auth plugin / protocol** — the default authentication plugin or minimum TLS/logon version may
+      change (affects how the app's connector authenticates).
+- [ ] **Optimizer plan changes** — new cost models / cardinality estimators can change query plans
+      across a major. Capture `EXPLAIN` baselines before; re-validate latency after.
+- [ ] **Parameter/option groups don't cross majors** — RDS will not auto-migrate a *custom* parameter
+      or option group to a new major family. Recreate it and **strip removed/deprecated parameters**
+      first, or the new instance can fail to apply the group.
+- [ ] **Validate after import** — object counts, `CHECKSUM TABLE` / aggregate checks across the gap,
+      and a full application regression/CRUD round-trip (see validation-patterns.md §4).
+- [ ] **Confirm the target major is offered on RDS/Aurora** for your engine before committing.
+
+---
+
+## MySQL / MariaDB
+
+### MariaDB 10.5 → 10.11 (reference migration)
+- Both LTS; 10.11 is a long-term-support release with a longer support horizon — good upgrade target.
+- `CHECKSUM TABLE` was **identical** across the gap for InnoDB/Dynamic tables — data fidelity intact.
+- Check: new **reserved words** added across 10.6–10.11 (e.g. `OFFSET`, window/CTE-related);
+  `utf8` now aliases `utf8mb3` (deprecation warnings) — prefer explicit `utf8mb4`.
+- Audit plugin / parameter-group settings (e.g. `MARIADB_AUDIT_PLUGIN`) are configured on the
+  **target** option/parameter group, not carried by the dump.
+
+### MySQL 5.7 → 8.0
+- **Default charset** changed `latin1` → **`utf8mb4`**, default collation `utf8mb4_0900_ai_ci`.
+  This is the most common surprise — verify column/table charsets and re-check sort order/collation
+  (validation-patterns.md §4 collation check).
+- **Default auth plugin** changed `mysql_native_password` → **`caching_sha2_password`** — older
+  connectors may fail to authenticate; either upgrade the connector or create the user with the
+  legacy plugin.
+- Many **new reserved words** (`RANK`, `ROW`, `GROUPS`, `LEAD`, `LAG`, `CUME_DIST`, `OVER`, …) —
+  quote any identifier that collides.
+- `sql_mode` defaults stricter (`ONLY_FULL_GROUP_BY` etc.) — queries that relied on loose grouping
+  break.
+- Removed: query cache, some deprecated `GROUP BY ... ASC/DESC` syntax.
+
+### MySQL 8.0 → 8.4 (latest LTS)
+Target of choice for new migrations — 8.0 reaches RDS end of standard support **2026-07-31**, so
+land on **8.4 LTS** (RDS GA 2024-11-21; community EOL 2029-04-30, RDS standard support to 2029-07-31).
+
+- **`mysql_native_password` disabled by default** — the plugin still ships but is **OFF at startup**.
+  Accounts created with it (and old PHP/JDBC/legacy connectors) **fail to authenticate** until you
+  set `mysql_native_password=ON` in the 8.4 parameter group, or recreate users on
+  `caching_sha2_password`. *Highest-impact app breakage of this hop.* Plugin is deprecated and slated
+  for removal.
+- **`default_authentication_plugin` removed** → replaced by `authentication_policy`. A custom 8.0
+  parameter group that still references it will block startup — strip it before upgrading.
+- **InnoDB defaults re-tuned for modern hardware**, can shift I/O / memory footprint — benchmark:
+  `innodb_io_capacity` 200→10000, `innodb_log_buffer_size` 16M→64M, `innodb_adaptive_hash_index`
+  ON→OFF, `innodb_change_buffering` all→none, `innodb_flush_method`→`O_DIRECT`,
+  `innodb_numa_interleave` OFF→ON, `innodb_use_fdatasync` OFF→ON. Buffer-pool instance auto-sizing
+  formula also changed.
+- **Replication "master/slave" SQL fully *removed*** (not just deprecated/aliased) — any tooling
+  using the old verbs hard-errors:
+  - `CHANGE MASTER TO` → `CHANGE REPLICATION SOURCE TO` (and all `MASTER_*` → `SOURCE_*` options)
+  - `START/STOP/RESET SLAVE` → `START/STOP/RESET REPLICA`; `SHOW SLAVE STATUS` → `SHOW REPLICA STATUS`
+  - `RESET MASTER` → `RESET BINARY LOGS AND GTIDS`; `SHOW MASTER STATUS` → `SHOW BINARY LOG STATUS`
+- **App-breaking specifics:** `AUTO_INCREMENT` on `FLOAT`/`DOUBLE` now rejected; `LOW_PRIORITY` with
+  `LOCK TABLES ... WRITE` is a syntax error; non-unique / partial keys as FK-referenced keys
+  restricted by default (`restrict_fk_on_non_standard_key=ON`); weak TLS ciphers removed (need
+  TLS 1.2+ with PFS/SHA2/AEAD); `WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS()` removed.
+- **New reserved words: `PARALLEL`, `QUALIFY`, `TABLESAMPLE`, `MANUAL`** (confirmed) — quote any
+  colliding identifier. *(Several reported new non-reserved keywords — `AUTO`, `BERNOULLI`, `GTIDS`,
+  `LOG`, `PARSE_TREE`, `S3` — are unverified; non-reserved words don't break identifiers regardless.)*
+- **Removed system variables** (block startup if left in a parameter group): `expire_logs_days`
+  (use `binlog_expire_logs_seconds`), `binlog_transaction_dependency_tracking`,
+  `transaction_write_set_extraction`, `log_bin_use_v1_events`, `group_replication_ip_whitelist`
+  (→ `..._ip_allowlist`), the legacy `keyring_file_*`/`keyring_encrypted_file_*` variables
+  (→ keyring **components**), plus `default_authentication_plugin` (above).
+- **Removed tooling**: `mysql_upgrade` (server self-upgrades), `mysqlpump`, `mysql_ssl_rsa_setup`.
+  Removed plugins: `authentication_fido` (→ `authentication_webauthn`), `keyring_file`/
+  `keyring_encrypted_file`/`keyring_oci`. `utf8mb3`/`utf8` charset now **deprecated** — migrate to
+  `utf8mb4` (MySQL 9.x stops accepting the `utf8` name as a startup option).
+- **RDS notes:** only **8.0 → 8.4** is supported as a major hop (no skipping); upgrades are never
+  automatic. Use a new **`mysql8.4` parameter-group family** (cannot reuse `mysql8.0`) and audit it
+  for the removed variables above. **Blue/Green Deployments** support the 8.0 → 8.4 hop and are the
+  recommended low-downtime path. On 8.4.4+, **drop spatial indexes before upgrade** and recreate
+  after.
+
+### MySQL 5.7 end-of-life note
+- **Community support ended 2023-10-31**; **RDS end of standard support 2024-02-29.** Still-running
+  5.7 instances are auto-enrolled into **RDS Extended Support** (no downtime, frozen on the
+  `5.7.44-RDS.<date>` line with AWS-backported critical/high CVE fixes).
+- **Extended Support is paid and time-boxed:** billing started 2024-03-01; years 1–2 ran to
+  2026-02-28, year-3 pricing from 2026-03-01, and **RDS Extended Support ends 2027-02-28** — after
+  which RDS will **force-upgrade the major version** for you. Pricing is per-vCPU-hour and roughly
+  *doubles* in year 3 (e.g. us-east-2 ~$0.10 → ~$0.20 /vCPU-hour; varies by region — check the RDS
+  MySQL pricing page).
+- **Why move now:** cost scales with vCPU count (large fleets get expensive fast), you only get
+  critical-CVE fixes (no feature/bug work), and 5.7 → 8.0 is itself a heavy upgrade (data-dictionary
+  rebuild, charset/collation, auth) — better planned than done under a force-upgrade deadline. For a
+  fresh migration, target **8.4 LTS** directly rather than 8.0.
+
+### MariaDB 10.6 → 10.11 (LTS → LTS, low-risk path)
+Both LTS; 10.11 has a much longer support runway (RDS minors to 10.11.18, EOSS into mid-2027 vs the
+10.6 track winding down sooner). Staying inside 10.x **avoids the 11.0 optimizer rewrite and the
+SUPER-split breakage** — the conservative choice. RDS supports a direct in-place 10.6 → 10.11 hop.
+
+- **`explicit_defaults_for_timestamp` default OFF → ON (10.10)** — *most impactful silent change in
+  this path.* No implicit `DEFAULT CURRENT_TIMESTAMP` / `ON UPDATE`, NULL handling changes. Apps
+  relying on legacy auto-timestamp behavior break silently — test all `TIMESTAMP` DDL.
+- **New reserved word `ROW_NUMBER` (10.7)** — audit for columns/aliases named `row_number` (`OFFSET`
+  was already reserved at 10.6). No further general reserved-word additions through 10.11.
+- **Other default changes:** `--ssl` becomes the `mariadb` CLI default (10.10);
+  `innodb_buffer_pool_chunk_size` autosized (10.11).
+- **Deprecations/removals:** `DES_ENCRYPT`/`DES_DECRYPT` deprecated (10.10); `innodb_disallow_writes`
+  removed (10.9); `innodb_change_buffering` deprecated (10.9 — foreshadows its 11.0 removal);
+  `innodb_log_file_size` made dynamic (10.9). `utf8` still aliases `utf8mb3` (lever:
+  `old_mode=UTF8_IS_UTF8MB3`).
+- **New features you can adopt:** `UUID`/`INET4` data types, `JSON_EQUALS`/`JSON_OVERLAPS`/
+  `JSON_NORMALIZE`, `NATURAL_SORT_KEY()`, `RANDOM_BYTES()`.
+- **Compression caveat:** InnoDB/Mroonga tables using a **non-zlib** compression algorithm on 10.6
+  are unreadable on 10.11 unless the matching library is present (managed on RDS, but verify).
+- RDS runs the equivalent of `mariadb-upgrade` automatically as part of the managed upgrade.
+
+### MariaDB 10.x → 11.x (major architecture change)
+11.4 is the current LTS on RDS (RDS also offers 11.8). **11.0 is the breaking boundary** — treat this
+as more than a version bump. RDS supports a direct in-place upgrade from any 10.6/10.11 instance
+straight to 11.4/11.8.
+
+- **New optimizer cost model (11.0) — the single biggest app-impacting change.** Cost is now
+  *time-based* (storage-engine ops in ms, user costs in µs). The old hard-coded heuristics are gone
+  (the "key lookups capped at 10% of rows" rule and InnoDB's "50% of rows in a range" cap). **Query
+  plans can change after upgrade** — usually better, sometimes not. Worst-hit shapes: multi-table
+  joins, ranges over >10% of a table, indexes with many duplicates, mixed-storage-engine queries.
+  **#1 regression-test item** — capture `EXPLAIN`/`EXPLAIN ANALYZE` baselines before cutover. New
+  tunables exist (`optimizer_disk_read_cost`, `optimizer_where_cost`, …; engine costs cache at
+  table-load, so `FLUSH TABLES` after changing them).
+- **SUPER privilege fully de-coupled (11.0.1)** — the granular privileges carved out in 10.5
+  (`SET USER`, `CONNECTION ADMIN`, `BINLOG ADMIN`, `REPLICATION SLAVE ADMIN`, `READ_ONLY ADMIN`, …)
+  are **no longer implied by `SUPER`**. Accounts/automation relying on `GRANT SUPER` for replication
+  admin, read-only toggling, etc. start getting **access-denied** until granted explicitly. Most
+  common admin/automation breakage.
+- **InnoDB Change Buffer removed (11.0)** — `innodb_change_buffering` and
+  `innodb_change_buffer_max_size` are **removed**; left in a parameter group they **block startup**
+  (strip them from the 11.x parameter group). Behavioral change for write-heavy secondary-index
+  workloads.
+- **Default changes:** `innodb_undo_tablespaces` 0 → 3 (11.0); `histogram_type`
+  `DOUBLE_PREC_HB` → `JSON_HB` (11.0, affects optimizer stats); `innodb_purge_batch_size` 300 → 1000
+  (by 11.4). `utf8` still aliases `utf8mb3` (silent 4-byte/emoji truncation risk for teams expecting
+  `utf8mb4`). No forced auth-plugin change at 11.0 (`ed25519`/`mysql_native_password` remain; 11.4
+  adds `parsec`). *(`require_secure_transport=1` becomes default at **11.8**, not 11.4.)*
+- **Reserved words:** `ROW_NUMBER` (from 10.7), `VECTOR` (from 11.6 — relevant only if target ≥ 11.6).
+  No new general reserved words specifically at 11.0–11.4.
+- **Deprecations:** all `innodb_defragment*` options, `innodb_file_per_table`, `innodb_flush_method`,
+  `tx_isolation`/`tx_read_only` (→ `transaction_isolation`/`transaction_read_only`, 11.4). The
+  `mysql*`-named CLI tools are aliases for `mariadb*` (e.g. `mysqldump` → `mariadb-dump`); legacy
+  symlinks still ship but migrate scripts to the `mariadb-*` names.
+- **RDS notes:** major upgrade requires a new/custom parameter group for the 11.x family and a
+  customer-initiated reboot; RDS takes pre/post snapshots. **Use Blue/Green** to validate the new
+  cost-model plans against production traffic before cutover.
+
+### MySQL/MariaDB cross-engine note
+MySQL and MariaDB diverged after 5.5 — treat **MySQL → MariaDB** (or vice-versa) as more than a
+version bump: JSON type semantics, sequence support, auth plugins, and some functions differ.
+Validate carefully.
+
+---
+
+## PostgreSQL
+
+> RDS supports **skip-version** major upgrades (e.g. 13 → 15 in one step) via `pg_upgrade` or
+> **Blue/Green** (Blue/Green switches to *logical* replication when the green is a higher major —
+> needs source minor roughly ≥ 16.1 / 15.4 / 14.9). Targets are version-pair specific — confirm with
+> `aws rds describe-db-engine-versions`. As of 2026-06, PG12 is Extended-Support-only (standard
+> support ended 2025-02-28).
+
+### PostgreSQL generic checklist
+- **`pg_dump` from the lower version, restore into the higher** — run a `pg_dump` whose client
+  version **matches or exceeds the target** server version.
+- Watch **removed/renamed system catalogs and functions** across majors (e.g. `pg_stat_*` column
+  renames; removed operators; `xml`/`json` handling changes).
+- **`standard_conforming_strings`**, default `timezone`, and `bytea_output` defaults have shifted
+  historically — confirm app assumptions.
+- New **reserved keywords** are added per major — quote colliding identifiers.
+- Re-run `ANALYZE` after import (statistics are not dumped).
+- **Pre-upgrade `pg_upgrade` blockers:** open prepared transactions, unsupported `reg*` types,
+  logical replication slots (must be dropped pre-PG17), invalid databases (`datconnlimit = -2`),
+  millions of large objects. Single-AZ/Multi-AZ-instance read replicas upgrade with the primary;
+  **Multi-AZ DB cluster** readers must be recreated.
+
+#### PostgreSQL 12 → 13
+- **btree deduplication** (space/perf win for low-cardinality indexes) — **not applied to indexes
+  carried over by `pg_upgrade`**; `REINDEX` to benefit. Incremental sort (on by default) and
+  hash-aggregate disk spill (`hash_mem_multiplier`) can change plans/memory.
+- **Partitioning** improvements: better pruning, partitionwise joins across non-identical bounds,
+  row-level BEFORE triggers, logical replication of partitioned tables.
+- **App-breaking / silent:** `SIMILAR TO ... ESCAPE NULL` and `substring(... ESCAPE NULL)` now return
+  **NULL**; `ALTER FOREIGN TABLE`/`ALTER MATERIALIZED VIEW ... RENAME COLUMN` return their own command
+  tags (was `ALTER TABLE`) — breaks tag-parsing tooling; several wait events renamed.
+- **Defaults:** `wal_keep_segments` **renamed** `wal_keep_size` (MB) — update custom parameter
+  groups; `ssl_min_protocol_version` → TLSv1.2; `effective_io_concurrency` semantics changed
+  (re-tune).
+- **Removed:** `CREATE EXTENSION ... FROM` (package extensions *before* upgrading);
+  pre-8.0 operator-class and `posixrules` timezone files. *(`WITH OIDS` and `recovery.conf` removal
+  were PG12, not 13.)* No notable new reserved words.
+- **RDS:** cleanest hop of the set; PG12 is Extended-Support-only so 12 → 13 is often forced — many
+  customers skip straight to 15+.
+
+#### PostgreSQL 13 → 14
+- **`password_encryption` default → `scram-sha-256`** (was `md5`) — **biggest operational gotcha.**
+  Affects only *newly set* passwords; old md5 hashes still work, but legacy drivers (old JDBC, libpq,
+  pgbouncer) may fail SCRAM — verify client versions. On RDS the default is set by the parameter group
+  (new PG14 default groups use scram-sha-256).
+- **App-breaking / silent (heavy release):**
+  - **`EXTRACT()` now returns `numeric`** (was `float8`) — silent type/precision shift downstream.
+  - **Array functions changed `anyarray` → `anycompatiblearray`** (`array_append`, `array_cat`,
+    `array_position`, …) — **user-defined aggregates/operators referencing them must be dropped &
+    recreated** (`pg_upgrade` surfaces these).
+  - **Postfix (right-unary) operators removed** — custom `CREATE OPERATOR (RIGHTARG=...)` invalid;
+    **factorial `!`/`!!` removed** (use `factorial()`). Geometric `@`/`~` removed (→ `@>`/`<@`).
+  - `pg_hba.conf` `clientcert=1/0/no-verify` removed → `verify-ca|verify-full`. Protocol v2 / SSL
+    compression removed.
+- **Defaults:** `checkpoint_completion_target` 0.5 → **0.9**. New predefined roles `pg_read_all_data`,
+  `pg_write_all_data`, `pg_database_owner`. New features: multirange types, CTE `SEARCH`/`CYCLE`,
+  JSONB subscripting, libpq pipeline mode.
+- **Reserved words:** PG14 **reduced** keyword restrictions — no new hard-reserved words of concern.
+- **RDS:** audit driver SCRAM support; array-function and postfix-operator breaks are the most common
+  `pg_upgrade` failures here — run the precheck, drop/recreate dependent objects first.
+
+#### PostgreSQL 14 → 15  ⚠️ HIGH-RISK PAIR
+- **🚨 `public` schema `CREATE` revoked from `PUBLIC`** — the single most app-breaking change in the
+  whole 12→17 range (CVE-2018-1058 mitigation). Non-owner roles **can no longer create objects in
+  `public`** by default → `permission denied for schema public`. `public` is now owned by
+  `pg_database_owner`.
+  - **Critical RDS nuance:** applies to databases **created on** PG15. An in-place `pg_upgrade` of an
+    *existing* DB **preserves the old permissive ACL** — so the break often surfaces only later, when
+    teams create a *new* DB, restore a dump into a fresh DB, or stand up a Blue/Green green that
+    re-initializes. **Test new-database creation explicitly.** Restore per-DB with
+    `GRANT CREATE ON SCHEMA public TO PUBLIC;` (better: grant to the specific app role).
+- **Stats collector process removed** — cumulative stats now in **shared memory**;
+  **`stats_temp_directory` removed** (strip from custom parameter groups or the group is rejected).
+- **App-breaking / silent:** login roles no longer get ADMIN OPTION on their own role by default;
+  `123abc` (number+letters) is now a **syntax error**; interval fractional units round
+  (`1.99 years` → `2 years`) — silent value change; `chr()` errors on negative input.
+- **Defaults:** `log_checkpoints` off → **on**; `log_autovacuum_min_duration` -1 → **10min**;
+  `hash_mem_multiplier` 1.0 → **2.0** (watch memory). New: **MERGE**, logical-replication row
+  filters/column lists, server-side base-backup compression, `jsonlog`.
+- **Removed:** **exclusive backup mode** (`pg_start_backup`/`pg_stop_backup` → `pg_backup_start`/
+  `pg_backup_stop`); **PL/Python 2** (`plpythonu`/`plpython2u` → `plpython3u`); `stats_temp_directory`.
+- **RDS:** highest-risk hop. Mandatory tests: (1) new-DB `public` CREATE behavior, (2) no
+  `stats_temp_directory` in the parameter group, (3) PL/Python on Python 3, (4) plan for increased
+  log volume.
+
+#### PostgreSQL 15 → 16
+- **Logical replication from a standby** (logical decoding on read replicas); parallel apply of large
+  transactions. New **`pg_stat_io`** view for per-backend-type I/O observability.
+- **ICU collation provider** can be the default and is now built by default — new PG16 databases may
+  default to ICU; **collation-provider mismatches can change sort order and break collation-dependent
+  indexes/queries.** Verify locale/collation provider on new RDS databases.
+- **App-breaking / silent (privilege/role traps):**
+  - **CREATEROLE no longer god-mode** — a CREATEROLE role can only grant/alter roles it has ADMIN
+    OPTION on, and can only set CREATEDB/REPLICATION/BYPASSRLS if it holds them. Role-provisioning
+    automation written for ≤15 frequently breaks. Interacts with `rds_superuser`.
+  - **Role inheritance set at GRANT time** (`WITH INHERIT TRUE/FALSE`) per-membership — changes
+    effective privileges after upgrade in mixed setups.
+  - **Logical-replication apply now runs as the table owner** (not subscription owner); restore old
+    behavior with `WITH (run_as_owner = true)`.
+  - `REINDEX DATABASE`/`SYSTEM` no longer reindex system catalogs by default (use `reindexdb --system`).
+- **Removed:** `force_parallel_mode` → `debug_parallel_query`; **`promote_trigger_file` removed**
+  (use `pg_promote()`); `vacuum_defer_cleanup_age` removed. No notable new reserved words.
+- **RDS:** lower app-surface risk than 14→15, but **role/privilege automation is the trap** — audit
+  any tooling that provisions roles or owns subscriptions; confirm collation provider on new DBs.
+
+#### PostgreSQL 16 → 17 (latest standard target; RDS also offers 18)
+- **New `MAINTAIN` privilege + `pg_maintain` role** — delegate `VACUUM`/`ANALYZE`/`REINDEX`/
+  `REFRESH MATERIALIZED VIEW`/`CLUSTER` without ownership (off the owner/`rds_superuser`).
+- **Incremental file-system backup** (`pg_basebackup --incremental` + `pg_combinebackup`); VACUUM
+  memory mgmt rewritten (no longer 1 GB-capped). **SQL/JSON**: `JSON_TABLE()`, `JSON_QUERY()`,
+  `JSON_VALUE()`, `JSON_EXISTS()`. `pg_upgrade` now **preserves logical replication slots** (source
+  17+) — eases CDC/DMS migrations.
+- **App-breaking / silent:**
+  - **Restricted `search_path` during maintenance ops** (`ANALYZE`/`CLUSTER`/`REINDEX`/`VACUUM`/
+    `CREATE INDEX`/MV refresh). **Functions in expression indexes / materialized views that rely on a
+    non-default schema can fail** unless they `SET search_path` at creation — common real-world break
+    for index/MV-heavy schemas.
+  - **`pg_stat_statements` columns renamed** (`blk_read_time` → `shared_blk_read_time`, etc.) and
+    `pg_stat_bgwriter` loses `buffers_backend*` (moved to new **`pg_stat_checkpointer`**) — **breaks
+    monitoring dashboards.**
+  - `SET SESSION AUTHORIZATION` now checks superuser status at command time.
+- **Defaults:** new params `transaction_timeout`, `allow_alter_system`, `summarize_wal`,
+  `sync_replication_slots`. No notable new reserved words.
+- **Removed:** **`adminpack` contrib removed** (drop it before upgrading — `pg_upgrade` blocker);
+  **`old_snapshot_threshold` removed**; `db_user_namespace` removed.
+- **RDS:** must-dos: (1) **drop `adminpack`** if present; (2) fix monitoring queries for renamed
+  `pg_stat_statements`/`pg_stat_bgwriter` columns; (3) audit functions used in expression indexes/MVs
+  for explicit `search_path`.
+
+#### Extensions that may break across versions
+- **The engine upgrade does NOT upgrade extensions.** After every major, for each one run
+  `ALTER EXTENSION <name> UPDATE;`. Inventory with `SELECT * FROM pg_extension;`; check targets on the
+  **target** engine via `SELECT * FROM pg_available_extension_versions;` (requires `rds_superuser`).
+- **Minimum supported version per major** — an extension version fine on PG14 may be too old to load
+  on PG16/17, so you may need to bump it *as part of* the upgrade. AWS may also **drop** an extension
+  (≥12-month notice) — check it still exists on the target.
+- **Special-case (don't just `ALTER EXTENSION`):** **PostGIS** has its own multi-step upgrade
+  (`postgis_extensions_upgrade()`) — highest-risk extension; **`pg_repack`** must be dropped &
+  recreated; **`pglogical`** replication slots must be dropped before the engine upgrade.
+- **Validate explicitly:** `pg_stat_statements` (PG16→17 column renames — re-baseline dashboards);
+  **`pgvector`** (fast-moving — confirm the target offers the index types/operators your app uses
+  (e.g. HNSW), then `ALTER EXTENSION ... UPDATE`; reindex if the build format changed); `pg_cron`
+  (confirm compatible version, re-validate jobs).
+- **Process:** snapshot `pg_extension` (name+version) pre-upgrade, confirm each has a supported target
+  version, sequence PostGIS/`pg_repack`/`pglogical` specially, then `ALTER EXTENSION ... UPDATE`
+  everything immediately post-upgrade and smoke-test.
+
+---
+
+## Oracle
+
+> **RDS for Oracle supports only 19c and 21c.** **19c is the long-term support release** (Premier
+> support via RDS to 2029-12-31; BYOL Extended/ULA to 2032-12-31). **21c is an Innovation Release with
+> a short runway** (RDS support ~2027-07; **not eligible for Extended Support**) — most customers
+> should land on **19c** and skip 21c, or wait for 23ai. **23ai is not GA on standard RDS for Oracle**
+> as of 2026-06 (verify at delivery time). RDS gives ≥12 months notice before a forced major upgrade.
+
+> **Real-world method.** RDS has no host access, so you **cannot run DBUA / AutoUpgrade / `catctl.pl`**.
+> Cross-version Oracle migrations to RDS typically use **AWS DMS (CDC)** or **Data Pump
+> (`expdp`/`impdp`** via `DATA_PUMP_DIR` + the RDS-S3 integration option), optionally **GoldenGate**
+> for near-zero downtime. This lets you provision a fresh target (CDB, AL32UTF8) and move data in —
+> the logical-migration model this doc is about.
+
+#### Oracle 12c → 19c (common upgrade path)
+12.1/12.2 reached Oracle end-of-support in 2022 and are force-upgraded on RDS — the dominant
+real-world migration.
+
+- **Case-sensitive passwords / `ORA-28040: No matching authentication protocol`** — *the* most common
+  post-upgrade failure. 19c phases out the 10G verifier and raises
+  `SQLNET.ALLOWED_LOGON_VERSION_SERVER`; old clients/JDBC are rejected and accounts whose passwords
+  were set under `SEC_CASE_SENSITIVE_LOGON=FALSE` (10G-only verifier) **must be reset**. Pre-check
+  `DBA_USERS.PASSWORD_VERSIONS` for accounts showing only `10G`; upgrade clients/drivers.
+  `SEC_CASE_SENSITIVE_LOGON` is **deprecated**.
+- **Optimizer plan changes** — 19c CBO can produce different/worse plans. Mitigate with
+  `OPTIMIZER_FEATURES_ENABLE='12.2.0.1'` and SQL Plan Baselines; **gather dictionary + fixed-object +
+  system stats before cutover** (RDS docs explicitly recommend this to cut downtime).
+- **App-breaking removals:** `DBMS_LOGMNR ... CONTINUOUS_MINE` **removed** (breaks legacy
+  LogMiner/CDC — use DMS/GoldenGate); **`PRODUCT_USER_PROFILE` (PUP)** desupported (SQL*Plus command
+  restrictions no longer enforced); **Oracle Multimedia (`ORDIM`)** desupported (store media as
+  SecureFiles LOBs); **Oracle Streams** desupported; original `exp` deprecated; `DBMS_JOB` deprecated
+  (→ `DBMS_SCHEDULER`).
+- **Architecture:** **non-CDB is deprecated** (since 12.2) — direction is multitenant (CDB/PDB). On
+  RDS you connect to the **PDB/tenant**, not `CDB$ROOT`.
+- **Init params:** scrub **deprecated parameters** (`O7_DICTIONARY_ACCESSIBILITY`, older `SEC_*`,
+  etc.) from the custom parameter group or the upgrade can stall;
+  `SQLNET.ALLOWED_LOGON_VERSION_SERVER` default tightened (root of ORA-28040).
+- **RDS notes:** recreate the **option group + parameter group** for `oracle-ee-19` (or
+  `oracle-ee-cdb-19`) — RDS won't auto-migrate custom groups across majors. **Character set is fixed
+  at creation** (default **AL32UTF8**) — a logical (DMS/Data Pump) migration is the clean way to
+  consolidate legacy single-byte charsets onto AL32UTF8. **Timezone/DST file** isn't auto-upgraded —
+  add the **`TIMEZONE_FILE_AUTOUPGRADE`** option (Data Pump raises **`ORA-39405`** if target TZ <
+  source). Backup retention > 0 so RDS takes pre/post snapshots (no rollback — restore the
+  pre-upgrade snapshot to a new instance).
+
+#### Oracle 19c → 21c on RDS
+21c is an Innovation Release; the only in-place RDS path is a **19c CDB → 21c** (21c is CDB-only).
+SAs frequently advise **staying on 19c** given 21c's short runway and no Extended Support.
+
+- **21c is CDB-only** — the non-CDB architecture is fully removed. A **19c non-CDB cannot go
+  directly**: first convert it to a 19c CDB (requires the April 2021 RU or higher,
+  `oracle-cdb-converting`), then upgrade. App/scripts assuming a non-CDB must be CDB/PDB-aware (RDS
+  already connects you to a PDB endpoint, which softens this).
+- **Removals/deprecations:** **Oracle Multimedia fully removed**; traditional auditing **deprecated**
+  (use Unified Auditing — on RDS, enable auditing **per-PDB**, not from `CDB$ROOT`); original `exp`
+  deprecated; OLAP deprecation continues. **`IGNORECASE` (ORAPWD) desupported in 21c** (10G-verifier
+  removal continues).
+- **New in 21c** (relevant to target choice): **native `JSON` datatype**, **blockchain/immutable
+  tables**, enhanced In-Memory/sharding/in-DB ML — but these also exist/expand in 23ai, another reason
+  to skip short-lived 21c.
+- **Optimizer regressions** — same `OPTIMIZER_FEATURES_ENABLE` discipline; test SQL.
+- **RDS notes:** target RU must be same-month-or-later than current; recreate option/parameter groups
+  for the **CDB families** `oracle-ee-cdb-21` / `oracle-se2-cdb-21` (strip deprecated params first).
+  Character set AL32UTF8, immutable; **CDB char set is always AL32UTF8** (only PDB can differ).
+  **CDB limitations to flag:** connect to PDB endpoint only; auditing per-PDB; no Database Activity
+  Streams in a CDB; option/parameter groups apply at CDB level. **SPBs (Supplemental Patch Bundles)
+  are 19c-only** — not available for 21c.
+
+> **Accuracy flag:** Oracle's live upgrade-guide URLs now redirect to a consolidated "26ai" page that
+> attributes desupports to the latest release. For a customer-facing doc, re-verify the exact "first
+> desupported in" version per item (esp. 21c reserved-word additions and the full 21c
+> desupported-parameter list) against the 19c/21c New Features Guide for your specific RU. No major
+> app-breaking SQL reserved-word additions are commonly cited for either hop — quote borderline
+> identifiers regardless.
+
+---
+
+## SQL Server
+
+> **RDS supports 2016, 2017, 2019, 2022** (2008/2012/2014 are gone). A single `modify` can hop
+> multiple majors (e.g. 2016 → 2022 directly). Major upgrades are **manual only** and **irreversible**
+> (RDS snapshots pre/post; rollback = restore the pre-upgrade snapshot to a new instance). EOS:
+> 2016 → 2026-07-14, 2017 → 2027-10-12, 2019 → 2030-01-08, 2022 → 2033-01-11. **License Included only**
+> (no BYOL); Web/Express don't support Multi-AZ.
+>
+> Version ↔ compat level: 2016 = 130, 2017 = 140, **2019 = 150, 2022 = 160**.
+
+#### SQL Server compatibility level concept (the key risk lever)
+- **What it controls** (per-database, independent of the engine binary): query-optimizer fixes (TF4199
+  auto-on at the new default level), **Cardinality Estimator (CE) version**, and certain T-SQL
+  semantics. Microsoft intentionally adds new plan-affecting behavior only at the new level to
+  minimize upgrade risk.
+- **RDS preserves each DB's compat level on upgrade** — existing DBs do **not** auto-jump to the new
+  engine's level; only freshly created DBs (and `model`) get it. So a **2016-era DB (compat 130) runs
+  fine on a 2022 engine**, deferring optimizer-plan regression risk.
+- **Recommended workflow ("Query Store as flight recorder," SQL 2016+):** (1) upgrade the engine
+  **keeping the old compat level** (gains Query Store + features, *not* new plans); (2) enable Query
+  Store; (3) capture a baseline at the old level over a full business cycle; (4) **raise compat level**
+  to expose the new optimizer; (5) use Query Store to find/fix regressions (force prior good plan; SQL
+  2017+ Automatic Plan Correction automates this; revert compat level if needed). SSMS Query Tuning
+  Assistant (QTA) compares across levels.
+- **Force legacy CE without lowering compat:** `LEGACY_CARDINALITY_ESTIMATION = ON`
+  (DB-scoped config / `USE HINT('FORCE_LEGACY_CARDINALITY_ESTIMATION')`).
+- **Compat level does NOT restore discontinued functionality** — removed/renamed system objects and
+  removed syntax (`*=`/`=*` joins, `FASTFIRSTROW`) error at any level. Minimum supported level on
+  2016–2022 is **100**.
+
+#### SQL Server 2016 → 2019
+- **Default compat level 130 → 150** on new DBs (preserved on in-place/restore), silently activating
+  the 2019 CE and all Intelligent Query Processing (IQP) features gated at 150.
+- **Scalar UDF inlining (compat 150, ON by default)** — *largest single app-breakage surface.*
+  Auto-rewrites scalar T-SQL UDFs into the calling query. Documented breakage: different query hash;
+  previously-hidden warnings surface (divide-by-zero); some join hints become invalid; views over
+  inlined UDFs can't be indexed; `SCOPE_IDENTITY()`/`@@ROWCOUNT`/`@@ERROR` can return different values
+  (scope change); inlined-UDF variable used as `FORCESEEK` column → **error 8622**. Disable:
+  `ALTER DATABASE SCOPED CONFIGURATION SET TSQL_SCALAR_UDF_INLINING = OFF`, per-function
+  `WITH INLINE = OFF`, or `USE HINT('DISABLE_TSQL_SCALAR_UDF_INLINING')`. (`sys.sql_modules.is_inlineable`
+  flags candidacy.)
+- **Other IQP-at-150** (ON by default, no Query Store needed): **batch mode on rowstore** (plans can
+  change; disable `USE HINT('DISALLOW_BATCH_MODE')`), **table-variable deferred compilation**
+  (parameter-sniffing-style regressions if row counts vary; disable
+  `USE HINT('DISABLE_DEFERRED_COMPILATION_TV')`), row-mode memory-grant feedback.
+- **UTF-8 (`_UTF8`) collation support introduced** (char/varchar only; nchar/nvarchar stay UTF-16).
+  **Silent truncation risk:** `varchar(n)` length `n` is *bytes* under UTF-8 — nvarchar→varchar(_UTF8)
+  can truncate multi-byte chars. No default-collation change at install (opt-in).
+- **Accelerated Database Recovery (ADR)** — opt-in; instant rollback / constant recovery, but more log
+  + Persistent Version Store growth (size RDS storage accordingly).
+- **Deprecated:** DQS, MDS. **Discontinued:** DB-scoped configs `DISABLE_BATCH_MODE_ADAPTIVE_JOIN`,
+  `DISABLE_BATCH_MODE_MEMORY_GRANT_FEEDBACK`, `DISABLE_INTERLEAVED_EXECUTION_TVF`. No reserved-word
+  additions (new syntax like `APPROX_COUNT_DISTINCT` is functions, not keywords).
+- **RDS:** single-modify hop. **CLR migration blocker** — RDS supports CLR (SAFE only) on 2016 and
+  lower but **not on 2017+**; CLR assemblies block a 2016 → 2017+ upgrade. 2016 EOS 2026-07-14 — plan
+  now.
+
+#### SQL Server 2019 → 2022 (latest on RDS)
+- **Default compat level 160** for new DBs; restored/upgraded DBs **keep prior compat** (IQP/CE below
+  activate only after explicit `ALTER DATABASE ... SET COMPATIBILITY_LEVEL = 160`). **Query Store ON
+  by default** for newly-created DBs.
+- **New IQP that silently changes plans (compat 160, ON by default):**
+  - **Parameter Sensitive Plan (PSP) optimization** — multiple cached plans per parameterized
+    statement. Variants run as prepared statements and **lose association with the parent module
+    `object_id`** in `sys.dm_exec_*` (only resolvable via Query Store) — can break monitoring; can
+    bloat plan cache. *Query Store AV under PSP fixed in 2022 CU7.* Disable:
+    `PARAMETER_SENSITIVE_PLAN_OPTIMIZATION = OFF` / `USE HINT('DISABLE_PARAMETER_SENSITIVE_PLAN')`.
+  - **CE feedback** (needs Query Store RW) — adjusts CE assumptions over executions; plans change
+    silently. *Runaway plan-cache memory/CPU bug introduced CU8, fixed CU12 (2024-04-22) — relevant on
+    builds CU8–CU11.* Disable `CE_FEEDBACK = OFF`.
+  - **Memory-grant feedback percentile + persistence** — persisted in Query Store; may *increase*
+    memory for oscillating workloads. **DOP feedback** is the only feedback feature **OFF by default**
+    (enable `DOP_FEEDBACK = ON`).
+- **Engine changes NOT gated by compat level (all editions):** VLF creation now 1 VLF (was 4) for
+  growth ≤ 64 MB; **IFI applies to transaction-log growth up to 64 MB**; service "Automatic" silently
+  runs as Automatic (Delayed Start).
+- **Removed — big migration breaker:** **SQL Server Native Client (SNAC / SQLNCLI / SQLNCLI11)** is
+  not shipped with 2022 — apps with SNAC/SQLNCLI connection strings break; migrate to **MSOLEDBSQL**
+  (OLE DB Driver) or **MSODBCSQL** (ODBC Driver). **Deprecated:** Distributed Replay, Machine Learning
+  Server, Stretch Database. **Discontinued:** Hadoop external data sources, PolyBase scale-out, Big
+  Data Clusters. SQL-generated certs now default RSA 3072-bit (was 2048). No reserved-word additions
+  (`DATE_BUCKET`, `GENERATE_SERIES`, `GREATEST`, `LEAST`, `JSON_OBJECT` are not reserved/gated).
+- **RDS notes:** 2022 GA on RDS. **Many headline 2022 features are NOT supported on RDS:** S3
+  backup/restore, External Data Source, TLS 1.3 & MS-TDS 8.0, SSAS, **database mirroring with Multi-AZ
+  (Always On is the only Multi-AZ method on 2022)**. **Ledger** tables (off by default) block
+  UPDATE/DELETE and can't be converted back.
+
+#### Deprecated features per version (especially what breaks on RDS)
+*DEPRECATED = still works, raises an event. DISCONTINUED = removed, breaks.* The 2016 engine-feature
+deprecation list is still in force through 2022 (2019/2022 added no new per-version engine table).
+
+- **App-breaking deprecated features:** **text / ntext / image** (+ `WRITETEXT`/`UPDATETEXT`/
+  `READTEXT`/`TEXTPTR()`) → `varchar(max)`/`nvarchar(max)`/`varbinary(max)`; **`SET ROWCOUNT` for
+  DML** → `TOP`; `SET FMTONLY` → `sp_describe_first_result_set`; legacy security procs
+  (`sp_addlogin`, `sp_adduser`, `sp_grantdbaccess`, `sp_password`, …) → `CREATE/ALTER LOGIN/USER/ROLE`;
+  `DBCC DBREINDEX`/`INDEXDEFRAG`/`SHOWCONTIG` → `ALTER INDEX` / `sys.dm_db_index_physical_stats`; all
+  `sys*` legacy system tables → catalog views; SQL Trace → Extended Events; `SQLOLEDB` →
+  `MSOLEDBSQL`; database mirroring → Always On AGs. Compat levels 100/110/120 are themselves
+  deprecated.
+- **SET options to be forced ON in a future version** (deprecated; "always ON" coming): `ANSI_NULLS
+  OFF`, `ANSI_PADDING OFF`, `CONCAT_NULL_YIELDS_NULL OFF` — code relying on `= NULL` matching NULLs
+  (`ANSI_NULLS OFF`) or trailing-blank trimming (`ANSI_PADDING OFF`) will break when this flips. *Not
+  yet forced as of 2022.*
+- **Discontinued (break now):** 2016 — 32-bit install, compat level 90, ActiveX subsystem,
+  `BACKUP ... WITH PASSWORD/MEDIAPASSWORD`. Old-style outer joins `*=`/`=*` (only valid at compat 90)
+  **fail on every supported version**.
+- **Detection:** before upgrading, find real usage via
+  `SELECT * FROM sys.dm_os_performance_counters WHERE object_name LIKE '%Deprecated Features%'`, or
+  trace the `deprecation_announcement` / `deprecation_final_support` Extended Events.
+
+#### SQL Server RDS — editions, collation, migration
+- **No in-place edition change** (up or down): snapshot → create new instance of the target edition →
+  migrate. Enterprise → Standard needs logical migration (native B/R or DMS) due to Enterprise-only
+  feature deps; Standard capped at 24 cores.
+- **Server collation set ONLY at instance creation** (`CharacterSetName`; default
+  `SQL_Latin1_General_CP1_CI_AS`) and **cannot be changed afterward, even via snapshot restore** — to
+  change it, create a new instance and migrate data in. Per-DB/table/column collation overridable via
+  `COLLATE`; UTF-8 collations available at server level.
+- **Native backup/restore (.bak via S3)** is the fastest migration method (RDS stored procs + IAM role
+  + option group; single-DB granularity; supports TDE). Limits: bucket same Region; no native *log*
+  backups; restore ≤ 64 TiB (5 TB/file); **Express restore capped at 10 GB**; max 2 concurrent tasks.
+  For low-downtime/filtered migration use **AWS DMS**.
+- **RDS does NOT support** (overlap with deprecated/blocked): xp_cmdshell/extended SPs, FILESTREAM &
+  FileTables, Replication, Log Shipping, Maintenance Plans, PolyBase, Stretch DB, server-level
+  triggers, `CREATE ENDPOINT`, database snapshots, DQS; **no OS/shell access, no sysadmin** (master
+  user gets `db_owner`). **CLR — SAFE only on 2016 and lower, not on 2017+.**
+
+---
+
+## After the upgrade
+
+> **Run the concrete post-upgrade validation checks in validation-patterns.md §4 →
+> "### Post-Version-Upgrade Validation".** That subsection (gated on source major ≠ target major) has
+> the actual queries/commands for the seven version-gap breaks — collation/sort-order *algorithm*
+> change, auth-plugin compatibility, `sql_mode` strictness, reserved-word collisions in the schema,
+> deprecated/removed functions in routines, default charset rendering (mojibake), and optimizer plan
+> regression. Use the per-version detail below to know *which* of those apply to your specific hop.
+
+1. `ANALYZE TABLE` (MySQL/MariaDB) / `ANALYZE` (PostgreSQL) / `DBMS_STATS` (Oracle) /
+   `UPDATE STATISTICS` (SQL Server) — statistics are not carried by a dump.
+2. Re-validate with object counts + `CHECKSUM TABLE`/aggregate checks across the version gap.
+3. Run the application regression suite (or minimum CRUD round-trip per table) against the new
+   version, watching for collation, sql_mode/optimizer, auth-plugin/protocol, and compatibility-level
+   behavioral changes.
+4. **Re-check query plans** against pre-upgrade `EXPLAIN` baselines (esp. MariaDB 11.x cost model,
+   Oracle CBO, SQL Server CE / compat level) — silent plan regressions are the most common
+   post-upgrade incident.
+5. Recreate/update **extensions, option groups, parameter groups** on the target major; re-validate
+   any monitoring queries that reference renamed catalog/DMV columns.
+6. Record the source→target versions and any behavioral changes handled in `migration-plan.md`.

--- a/db-migration-agent-skill/shared/templates/authorizations.md
+++ b/db-migration-agent-skill/shared/templates/authorizations.md
@@ -1,0 +1,51 @@
+# Authorizations of Record — {engagement} ({source} → {target})
+
+> **This file is the audit anchor.** Every gate sign-off, action-class authorization,
+> and waiver lives here with a named person and a date — chat approvals are working
+> conversation, not the record. `migration-plan.md` gate rows reference rows in this
+> file. Rules and action classes: `shared/reference/engagement-safety.md`.
+
+## 1. Engagement scope
+
+| | Value | Authorized by | Date |
+|---|---|---|---|
+| Engagement mode | {assessment-only / staging-rehearsal / production-migration} | | |
+| Criticality tier | {1 Standard / 2 Business-critical / 3 Mission-critical} — *basis:* {one line: what happens if this DB is wrong/down for an hour} | | |
+| Prior assessment report | {path/date of report that unlocks production mode / "this engagement, Phases 1–3"} | | |
+| IAM guardrail in place | {session policy / permissions boundary / simulate-proof} — Deny list active on {source ARNs} | | |
+
+## 2. Action-class authorizations (row required BEFORE first execution)
+
+| # | Action class | Exact scope | Authorized by | Date | Executed (ref) |
+|---|--------------|-------------|---------------|------|----------------|
+| A1 | Read-only source access | {DB user, hosts} | | | |
+| A2 | Source write: {each individually, e.g. "GRANT TRIGGER fix", "create migration user"} | {exact statements or script ref} | | | |
+| A3 | Target/production infrastructure deploy | {stack list} | | | |
+| A4 | Cutover execution | window {date/time TZ}, runbook {version/hash} | | | |
+| A5 | Rollback execution | {pre-authorized on abort criteria / requires call} | | | |
+| A6 | Decommission | {exact resource list} | | | |
+
+## 3. Gate sign-offs
+
+| Gate | What was approved | Approver | Date |
+|------|-------------------|----------|------|
+| GATE 1 | Discovery inputs + mode + tier locked | | |
+| GATE 2 | Method, cost, architecture, rollback strategy | | |
+| GATE 3 | Validation evidence accepted | | |
+| Soak exit (Tier ≥ 2) | {N} consecutive green days reached on {date} | | |
+| GATE 4 | Cutover go + abort criteria | | |
+| Decommission | Rollback window closed; teardown list | | |
+
+## 4. Waivers (tier requirements skipped — each needs all four columns)
+
+| What was skipped | Risk, stated plainly | Accepted by | Date |
+|------------------|----------------------|-------------|------|
+| | | | |
+
+## 5. Tier-3 only
+
+| | Value |
+|---|---|
+| Rehearsal convergence | run 1: {s} → run 2: {s} → run N: {s} (< 20% delta reached: {date}) |
+| Approver present at cutover | {name, confirmed} |
+| Reconciliation report sign-offs | {daily rows or ref to soak reports} |

--- a/db-migration-agent-skill/shared/templates/cutover-runbook.md
+++ b/db-migration-agent-skill/shared/templates/cutover-runbook.md
@@ -1,0 +1,72 @@
+# Cutover Runbook — {source} → {target} — {date} {window, TZ}
+
+> Generated at Phase 8 planning with **real values — zero placeholders may survive
+> generation**. Rehearsed against the clone on {rehearsal-date}. Every step has an owner,
+> an expected duration (from rehearsal), a verification, and an abort action. The
+> operator executes top-to-bottom; the agent tracks ✅ per step in `migration-plan.md`.
+
+**Roles:** operator: {name} · app owner: {name} · approver: {name}
+**Abort authority:** {name} — abort criteria at bottom apply at every step.
+**Comms:** {channel} — post at start, at each ⏱ checkpoint, at completion/abort.
+
+## T-24h — Prechecks
+| ✅ | Step | Command / action | Expect |
+|---|------|------------------|--------|
+| ▢ | Validation green (GATE 3) | see migration-plan.md Phase 7 | all ▢→✅ |
+| ▢ | Soak passed (Tier ≥ 2): {N} consecutive green days | migration-plan.md Phase 7.7 tracker | counter {N}/{N}; soak-exit row signed |
+| ▢ | Cutover authorization signed (A4) + abort criteria agreed | authorizations.md §2/§3 | named approver + date present |
+| ▢ | Client inventory complete | migration-plan.md Phase 7.5 | every client repoint-ready |
+| ▢ | Reverse replication task exists, endpoints tested, task NEVER RUN | `aws dms describe-replication-tasks --filters Name=replication-task-arn,Values={rev-arn}` | status `ready` (never `stopped` — a run task holds a stale CDC checkpoint; recreate it if rehearsal ran it) |
+| ▢ | DNS TTL lowered (if DNS cutover) | `aws route53 change-resource-record-sets …` TTL=60 | dig shows 60 |
+| ▢ | Connection pools pre-tuned | per-client values in migration-plan.md | maxLifetime≈30s |
+| ▢ | Alarms + dashboard on operator screen | CloudWatch dashboard {name} | no active alarms |
+
+## T-0 — Execution
+
+> Steps 3–8 (the freeze window) run as **one pre-staged script per host** (staged and
+> dry-run-tested at T-24h) — the operator issues one command per host, not one per step.
+> Interactive per-step dispatch (e.g. SSM send-command round-trips) adds 30–40 s each and
+> blows the budget. All engine-specific syntax below was verified against the actual
+> target version during prep.
+>
+> **This is a hard rule, not guidance — per-step dispatch and under-tested scripts are
+> the most common way a ≤60–120 s pause budget becomes 2–5 minutes.**
+> Executing freeze-window steps as separate remote commands is an abort-level deviation:
+> if the single script isn't staged and rehearsed/dry-run-clean, do not open the window.
+> Also pre-verify inside the script's dry-run mode: every parse of query output (a `-N`
+> flag with `\G` output does not parse), every account/grant the post-repoint app needs
+> on the target, the reverse-replication apply path, and **TLS trust against the EXACT
+> endpoint the app will connect to** — the RDS Proxy endpoint presents a different
+> certificate chain than the cluster/instance endpoints, so a CA bundle validated only
+> against the writer endpoint fails at the proxy connection probe (use the combined RDS
+> global bundle, or probe the proxy endpoint itself during the dry run).
+
+| ✅ | ⏱ est | Step | Command | Verify | Abort action |
+|---|-------|------|---------|--------|--------------|
+| ▢ | 1m | 1. Confirm CDC caught up | CDCLatencySource=0 ∧ CDCLatencyTarget=0 | metric=0 | wait / abort if climbing |
+| ▢ | 1m | 2. Maintenance mode ON | {app-specific} | banner up | — |
+| ▢ | 2m | 3. Freeze source ({read_only / stop-clients fallback}) | {exact command} | processlist: 0 writers | unfreeze, exit maint |
+| ▢ | 1m | 4. Final CDC drain | sleep 30; re-check latency=0 | =0 | resume, abort |
+| ▢ | 1m | 5. Stop forward task | `aws dms stop-replication-task --replication-task-arn {fwd-arn}` | `stopped` | restart task |
+| ▢ | 2m | 6. Spot-validate {3-5 critical tables} | {prepared count/checksum commands} | match | ROLLBACK |
+| ▢ | 2m | 7. Reset AUTO_INCREMENT / sequences on target | {generated statements file} | next-val > max | ROLLBACK |
+| ▢ | 1m | 8. Start REVERSE replication (fresh start from the freeze point — task must be never-run; see cutover-procedures.md step 8 note) | `aws dms start-replication-task --replication-task-arn {rev-arn} --start-replication-task-type start-replication` | `running` | note: rollback now lossy — decide |
+| ▢ | 1m | 9. Repoint: {secret update / DNS swap / config+unit change} | {exact command(s) per client} | — | revert repoint |
+| ▢ | 3m | 10. Refresh/restart clients ({coordinated / rolling-with-frozen-source}) | {per-client commands} | services up | revert + restart |
+| ▢ | 2m | 11. **Bidirectional verify** | app health = UP **and** target processlist shows {expected client IPs, ~pool counts} | both | ROLLBACK |
+| ▢ | 1m | 12. Maintenance mode OFF | {command} | traffic flowing | — |
+
+**Total budgeted write-pause: {n}s (rehearsed: {n}s).**
+
+## T+15m / T+1h / T+24h — Watch
+- Error rate {baseline}% → now: __ · p95 latency {baseline}ms → now: __
+- Reverse CDC lag: __ · Missing clients on processlist: __
+- Slow queries → run targeted `ANALYZE TABLE` before suspecting worse.
+
+## Abort / rollback criteria (from cutover-procedures.md — pre-agreed, not negotiable mid-incident)
+| Signal | Action |
+|--------|--------|
+| Error rate > 5% | Immediate rollback (execute rollback-runbook.md) |
+| p99 > 3× baseline, not improving in 5 min | Rollback |
+| Connection failures > 1% | 10 min to fix SG/creds, else rollback |
+| Any data-integrity doubt | Immediate rollback + investigate |

--- a/db-migration-agent-skill/shared/templates/migration-plan.md
+++ b/db-migration-agent-skill/shared/templates/migration-plan.md
@@ -1,0 +1,118 @@
+# Migration Plan — {source} → {target}
+
+> **This file is the working artifact and single source of truth for the engagement.**
+> The agent creates it at Phase 0 and updates it as every result lands. A step is "done"
+> only when its result is recorded here. Decisions carry their *why*. Chat scrollback is
+> not the record — this file is.
+
+| | |
+|---|---|
+| Engagement | {customer / project} |
+| **Engagement mode** | {assessment-only / staging-rehearsal / production-migration} (authorizations.md §1) |
+| **Criticality tier** | {1 / 2 / 3} — *basis:* {what happens if this DB is wrong for an hour} |
+| Source | {engine+version} on {EC2 instance-id / on-prem host} |
+| Target | {aurora-mysql / rds-postgresql / …} {version} in {region} |
+| Method (approved GATE 2) | {method} — *why:* {reason} |
+| Soak requirement (Tier ≥ 2) | {N} consecutive green days — tracker in §Phase 7.7 |
+| Cutover window | {date/time, TZ} |
+| Downtime budget | {seconds/minutes/hours} · RPO on rollback: {zero / acknowledged loss} |
+| Status | ⏳ Phase {n} |
+
+> Approvals of record live in **`authorizations.md`** (named person + date); gate rows
+> below reference it. IAM guardrail active: {session policy / boundary / simulate-proof}.
+
+## Phase 0 — Preflight ▢
+- Account/region verified: ▢ ({account-id}, {region})
+- IAM simulation passed: ▢ (gaps: …)
+- Quotas OK: ▢ · Engine version available: ▢ · CDK bootstrapped: ▢/n.a.
+- MCP servers connected: {list or "none — CLI fallback"}
+
+## Phase 1 — Discovery answers (GATE 1 sign-off: ▢ {date, by})
+| # | Question | Answer |
+|---|----------|--------|
+| 1 | Source engine/version/location | |
+| 2 | Target service/version | |
+| 3 | DB size / table count | |
+| 4 | Downtime tolerance | |
+| 5 | RPO if rollback | |
+| 6 | Bandwidth source→AWS (usable) | |
+| 7 | Stored procs/triggers/views needed | |
+| 8 | App code modifiable? | |
+| 9 | How app resolves DB host (secret/DNS/config/hardcoded) **and where that config is deployed FROM** (repo/pipeline/IaC/GitOps — the source of truth that must carry the change) | |
+| 10 | Downstream CDC consumers | |
+| 11 | Compliance/encryption mandates | |
+| 12 | Korean security appliances (access-control / encryption products + mode) | |
+| 13 | Multi-DB on host? Cross-DB queries? | |
+| 14 | Cross-region / cross-account? | |
+| 15 | KMS key type (AWS-managed / CMK) | |
+| 16 | **Criticality tier** (1/2/3 — "if wrong for an hour, what happens?") | |
+| 17 | **Third-party tools on/in front of the DB** (security, backup, monitoring, HA, proxy) | |
+| 18 | **Customer's own test suite / UAT scenarios** (regression tests, load tests, key business flows QA runs) — to be executed against the target during rehearsal and soak | |
+
+## Phase 2 — Assessment results
+- Blockers found & resolutions: …
+- Adjustments: …
+- Binlog/WAL state: `log_bin=…`, `binlog_format=…` / `wal_level=…`
+- Sizing: {GB}, largest tables: …
+- Throughput estimate: {hours} vs window {hours} → {fits / offline-seed branch}
+- Access path to source: {direct / bastion / SSM port-fwd / SSM send-command}
+- Performance baseline captured: ▢ (top-20 digests + EXPLAIN attached below)
+
+## Phase 3 — Method decision (GATE 2 sign-off: ▢)
+- Matrix row #: … · Alternatives rejected & why: …
+- Cost estimate presented: steady ~${}/mo, one-time ~${} — approved ▢
+
+## Phase 4/5 — Target provisioning
+- Immutables confirmed BEFORE create (charset/collation/block-size/license/KMS): ▢
+- Cluster: {id} · endpoint: … · RDS Proxy: {endpoint / n.a.}
+- Parameter groups: migration={name} production={name} · TLS enforced: {ON/OFF}
+- cdk synth ✅ ▢ · deployed ▢ · alarms live ▢
+
+## Phase 6 — Execution log
+| When (UTC) | Step | Result / evidence |
+|------------|------|-------------------|
+| | | |
+- CDC start position recorded (binlog file+pos / LSN / SCN): …
+- Rehearsal performed ▢ — measured durations: …
+
+## Phase 7 — Validation evidence (GATE 3 sign-off: ▢)
+- Row counts: {n}/{n} tables match ▢ · Checksums (critical tables): ▢
+- Schema-object counts source vs target: ▢ · FK orphans: 0 ▢
+- AUTO_INCREMENT/sequence high-water marks reset plan: ▢
+- App smoke test (read-only): ▢ · Version-gap checks (if major upgrade): ▢
+
+## Phase 7.5 — Client inventory (cutover blocked until every row is ✅✅)
+| Client | How it finds the DB (highest-priority source) | Config deployed from (repo/pipeline) | Change merged upstream | Pool prep done | Repointed | Verified on new DB processlist |
+|--------|-----------------------------------------------|--------------------------------------|:---:|:---:|:---:|:---:|
+| | | | ▢ | ▢ | ▢ | ▢ |
+
+Downstream replication/CDC consumers (Debezium/replicas/ELT — cutover-procedures.md §Step 4):
+| Consumer | Cutover plan (restart-from-target strategy) | Executed | Verified |
+|----------|---------------------------------------------|:---:|:---:|
+| | | ▢ | ▢ |
+
+## Phase 7.7 — Parallel-run soak (Tier ≥ 2; cutover locked until green)
+- Soak length: {N} consecutive green days · counter: {k}/{N}
+- Daily reports: {links to soak-report files}
+| Day | Verdict | Lag max | Spot checks | Notes |
+|-----|---------|---------|-------------|-------|
+| | 🟢/🔴 | | | |
+- Customer test traffic against target: {what they ran}
+- Soak-exit sign-off (authorizations.md §3): ▢
+
+## Phase 8 — Cutover (GATE 4 sign-off: ▢) 
+- Runbook generated & rehearsed: ▢ · Reverse replication created+tested (or alternative + RPO ack): ▢
+- Executed {timestamp} · write-pause measured: {s} · bidirectional verify ✅ ▢
+- Rollback decision points reviewed at T+15m ▢ T+1h ▢ T+24h ▢
+
+## Phase 9 — Post-migration
+- ANALYZE/stats ▢ · production parameter group swapped ▢ · scaled down ▢
+- Baseline vs new top-20 query comparison: ▢ (regressions: …)
+- Source decommission date: {cutover + 7d} · reverse replication stopped ▢ · DMS deleted ▢
+
+## Risk & assumption log
+| # | Risk/assumption | Mitigation / verification | Status |
+|---|-----------------|---------------------------|--------|
+
+## Rollback record (only if executed)
+- Trigger: … · executed runbook steps: … · data loss: {none / description}

--- a/db-migration-agent-skill/shared/templates/rollback-runbook.md
+++ b/db-migration-agent-skill/shared/templates/rollback-runbook.md
@@ -1,0 +1,35 @@
+# Rollback Runbook — fail back {target} → {source}
+
+> Generated alongside the cutover runbook with real values. Assumes the rollback strategy
+> approved at GATE 4: **{reverse-replication (lossless) / write-log replay / acknowledged-RPO}**.
+> Valid until {cutover + 7 days} — after source decommission this runbook is void.
+
+**Trigger:** one of the abort criteria in cutover-runbook.md, or approver decision.
+**Announce first:** {channel}. Rollback is itself a cutover — same discipline.
+
+## If reverse replication is running (lossless path)
+| ✅ | Step | Command | Verify |
+|---|------|---------|--------|
+| ▢ | 1. Maintenance mode ON | {command} | banner |
+| ▢ | 2. Freeze TARGET | `SET GLOBAL read_only=ON; SET GLOBAL super_read_only=ON;` on {target-endpoint} (PG: `default_transaction_read_only=on`) | 0 writers on target processlist |
+| ▢ | 3. Drain reverse CDC to 0 | CDCLatencySource=0 ∧ CDCLatencyTarget=0 on {rev-arn} | =0 |
+| ▢ | 4. Stop reverse task | `aws dms stop-replication-task --replication-task-arn {rev-arn}` | `stopped` |
+| ▢ | 5. Reset AUTO_INCREMENT/sequences on SOURCE above new max | {generated statements} | next-val > max |
+| ▢ | 6. Un-freeze source | {undo of cutover step 3 — read_only=OFF or start clients} | writable |
+| ▢ | 7. Revert repoint | {exact revert: secret → source values / DNS swap back / config+unit revert} | — |
+| ▢ | 8. Refresh/restart clients | {per-client commands} | up |
+| ▢ | 9. Bidirectional verify against SOURCE | health UP ∧ source processlist shows {client IPs} | both |
+| ▢ | 10. Maintenance OFF · keep TARGET running read-only (do NOT delete) | | |
+
+## If reverse replication was NOT possible ({chosen alternative})
+- **Write-log replay:** freeze target (steps 1–2) → export post-cutover writes from
+  {audit table / SQS / Kinesis / request log} since {cutover-ts} → replay against source
+  with {prepared replay script} → verify counts on affected tables → continue steps 6–10.
+- **Acknowledged RPO:** confirm with approver that writes from {cutover-ts}→now on the
+  target are accepted as lost (est. volume: query `{count query}` on target) → steps 6–10.
+  Record the actual loss in migration-plan.md §Rollback record.
+
+## Afterwards
+- Root-cause in migration-plan.md §Rollback record before any re-attempt.
+- Keep the target + DMS resources; re-sync with `--start-replication-task-type resume-processing` for attempt #2.
+- Re-run the full validation phase before scheduling the next window.

--- a/db-migration-agent-skill/shared/templates/soak-report.md
+++ b/db-migration-agent-skill/shared/templates/soak-report.md
@@ -1,0 +1,34 @@
+# Soak Report — Day {n} of {N} — {engagement} — {date}
+
+> Daily report for the Phase 7.7 parallel-run soak (Tier 2/3). Target is live and
+> CDC-current; production still runs on the source. Cutover unlocks only after
+> **{N} consecutive GREEN days** and the signed cutover authorization.
+> **Consecutive green counter: {k}/{N}** (any RED resets it to 0).
+
+## Verdict: {🟢 GREEN / 🔴 RED — reason}
+
+| Check | Threshold | Today | Pass |
+|-------|-----------|-------|:---:|
+| Replication lag (max over day) | < {5}s | {…} | ▢ |
+| Replication errors | 0 | {…} | ▢ |
+| Row-count spot check ({3-5 tables}, at a freeze-consistent instant) | exact match | {…} | ▢ |
+| Checksum spot check ({1-2 static tables}) | identical | {…} | ▢ |
+| Target alarms | none firing | {…} | ▢ |
+| Storage/connections headroom on target | > 30% | {…} | ▢ |
+| Schema drift (DDL on source since yesterday) | none unreplicated | {…} | ▢ |
+| **Customer test suite vs target** (if provided, Q18) | all pass | {suite: n pass / n fail} | ▢ |
+
+## Tier 3 additions
+
+| Check | Baseline (source) | Target today | Pass |
+|-------|-------------------|--------------|:---:|
+| Top-{10} statement plans (EXPLAIN diff) | {captured Phase 2} | {regressions: none/list} | ▢ |
+| Customer load test / read-only prod traffic result | {p95 baseline} | {p95 today} | ▢ |
+| Reconciliation aggregate(s): {e.g. SUM(ledger.amount) by day} | {value} | {value} | ▢ |
+
+## Notes / anomalies
+- {…}
+
+## Customer visibility
+Sent to: {names} · Questions raised: {none/list} · Customer test activity against target
+today: {none / what they ran}


### PR DESCRIPTION
## What this adds

A new Style 1 skill (`shared/` + thin SKILL.md) that turns Claude Code / Kiro / Codex into a database-migration engineer: it assesses an EC2/on-premises database (MySQL, MariaDB, PostgreSQL, Oracle, SQL Server, Db2), selects a migration method, provisions the Aurora/RDS target via CDK, migrates and validates, discovers and repoints every application client, and executes a rehearsed cutover with reverse-replication rollback — with the customer approving every consequential decision at explicit gates.

## Design highlights

- **Engagement modes + criticality tiers** asked before anything else: `assessment-only` (physically read-only), `staging-rehearsal` (clone only), `production-migration` (locked behind a prior assessment). Tier 1–3 scales the ceremony (rehearsal, parallel-run soak with daily green/red gates, reconciliation).
- **Approvals as artifacts**: a generated `authorizations.md` records every mode/tier/method/cutover sign-off and waiver with a named person and date; `migration-plan.md` is the running source of truth.
- **Native-tools-first method matrix** (18 rows): mysqldump/XtraBackup/pg_dump/logical replication/Data Pump/native .bak — DMS where it earns its place; heterogeneous conversion chains to the official `dms-schema-conversion` skill via the Agent Toolkit.
- **Client discovery and repointing** treated as the #1 operational risk: security-group tracing, config override-order (process args → env → systemd → config → secret → hardcoded IPs), containers, cron jobs, downstream CDC consumers — with changes landing in the customer's config source-of-truth, not just on live hosts.
- **Honest scope boundaries** in the README: no application-code editing (findings handoff instead), Oracle RAC not supported like-for-like, downtime numbers quoted only from measured rehearsals, explicit large-scale physics.
- **Korean-market depth**: domestic DB security appliance playbook (access-control/encryption products by attachment mode), PIPA / ISMS-P / network-separation mappings, Tibero/CUBRID/Altibase paths; the skill responds in the customer's language.

## Structure & conventions

- Folder `db-migration-agent-skill`, skill name `db-migration-agent` (kebab, no suffix) per CONTRIBUTING.
- Three md5-identical SKILL.md copies (synced with `scripts/sync-skills.sh`; verify passes).
- `shared/reference/` (18 docs), `shared/patterns/cdk-stacks.md`, `shared/templates/` (migration plan, authorizations, cutover/rollback runbooks, soak report), 2 `evals/` scenarios.
- Root README catalog row added.

## Testing

Exercised end-to-end against live AWS environments across multiple engines (MySQL, MariaDB incl. a full Korean-language engagement, PostgreSQL, SQL Server, and a MySQL 5.7→8.0 major-version jump) and across all three target agents in headless mode, including cutovers, an abort-criteria stop, and lossless rollbacks. Eval scenarios in `evals/` encode the expected behaviors.